### PR TITLE
Revise /beautiful_deck and /tikz as a shared deck-quality workflow

### DIFF
--- a/.claude/skills/beautiful_deck/README.md
+++ b/.claude/skills/beautiful_deck/README.md
@@ -21,6 +21,34 @@
 9. **Graphics audit (third agent)** — dispatches a second sub-agent focused only on numerical accuracy of figures/tables, label positioning, axis coherence, color consistency, and font sizing.
 10. **Final compile** — recompiles to a clean state and delivers.
 
+The skill also reads [`style_preferences.md`](style_preferences.md) for user-specific stylistic defaults. These are separate from the rhetorical principles in `rhetoric_of_decks.md`: rhetoric decides what the deck must accomplish; style preferences capture durable visual tastes that should carry across decks when they fit the audience and content. The file is currently populated with an example preference for reference; keep, edit, or delete it at the user's discretion.
+
+The included [`preamble_warm_professional.tex`](preamble_warm_professional.tex) is Scott's house style for outward-facing academic decks. It is useful as an opt-in reference preamble, but it should not anchor the palette or layout of original audience-specific designs unless the user asks for that house style.
+
+## Audience first — the load-bearing decision
+
+The very first thing the skill resolves is **who the audience is**. Audience determines the rhetorical balance, the aesthetic direction, the act proportions, and the pacing — every other decision in the skill depends on it. The skill will not proceed to source-content discussion, theme work, or anything else until audience is committed.
+
+The 5 canonical audience buckets:
+
+| Bucket | What it means |
+|---|---|
+| **Academic seminar** | PhD-level research talk, methods-aware audience |
+| **Teaching lecture** | Undergrad or grad course, clarity-first |
+| **Conference presentation** | 20-min talk, fast punch, headline-result-on-slide-2 |
+| **Working deck** | For coauthors, lab meetings, or future-self; rigor over polish |
+| **External non-academic** | Policy, media, industry — high pathos, minimal jargon |
+
+Provide audience in the invocation when you can. Examples:
+
+```
+/beautiful_deck "academic seminar" path/to/paper.pdf
+/beautiful_deck "teaching lecture" path/to/lecture_notes.md
+/beautiful_deck "external non-academic — policy briefing" "30-min talk on the CBS continuous DiD paper"
+```
+
+If audience is missing the skill will ask immediately (via a structured picker if available) before doing anything else. Free-text audience descriptions ("my advisor and one coauthor") are accepted — the skill maps them to the closest canonical bucket and confirms with you before proceeding. The "external non-academic" bucket has one follow-up sub-specifier (general public / policy / industry) because the rhetorical spread within that bucket is wider than within any other.
+
 ## Why the pedagogical movement matters
 
 The single most important rule in this skill is the ordering:
@@ -80,7 +108,7 @@ If the same compile error persists after 3 different fix attempts, **stop editin
 
 ## The Aristotelian triad
 
-The rhetorical balance changes with audience. The skill's triage step (Q2) commits to a specific balance before any slides are written.
+The rhetorical balance changes with audience. The skill's triage step (Q1) commits to a specific balance before any slides are written.
 
 | Audience | Logos | Ethos | Pathos |
 |---|---|---|---|
@@ -125,16 +153,26 @@ The skill will ask clarifying questions if anything in the triage step is missin
     └── ...
 ```
 
+## Dependencies
+
+**`/beautiful_deck` depends on `/tikz` being installed.** Two specific dependencies:
+
+1. **Step 4.4 (TikZ generation rules)** reads `~/.claude/skills/tikz/tikz_rules.md` for the canonical formula reference (gap calculations, Bézier curve depths, clearance tables). This file lives in the `tikz` skill folder so that both `/beautiful_deck` (generation-time) and `/tikz` (audit-time) read from a single source of truth.
+2. **Step 6 (visual cleanup)** invokes `/tikz` directly to audit residual collisions after the slides are written.
+
+If you install `/beautiful_deck` without `/tikz`, both steps will fail. Always install them as a pair.
+
 ## Related skills
 
-- **`/tikz`** — the measurement-based TikZ collision audit. Invoked during the visual cleanup step and used as the shared source for TikZ generation rules.
+- **`/tikz`** — the measurement-based TikZ collision audit. Invoked during the visual cleanup step. Required dependency (see above).
 - **`/referee2`** — the full five-audit protocol. `/beautiful_deck` uses a rhetoric-scoped variant of it in the audit step.
 - **`/split-pdf`** — if the source content is a paper Scott is reading, split it first and work from the summaries.
 
 ## The philosophy behind it
 
-Full essays:
-- [`presentations/rhetoric_of_decks.md`](../../presentations/rhetoric_of_decks.md) — the operational principles
-- [`presentations/rhetoric_of_decks_full_essay.md`](../../presentations/rhetoric_of_decks_full_essay.md) — the 600-line intellectual genealogy from Aristotle through LLMs
+Full essays (in this skill directory):
+- [`rhetoric_of_decks.md`](rhetoric_of_decks.md) — the operational principles
+- [`rhetoric_of_decks_full_essay.md`](rhetoric_of_decks_full_essay.md) — the 600-line intellectual genealogy from Aristotle through LLMs
+- [`style_preferences.md`](style_preferences.md) — user-specific stylistic defaults, including functional slide-header progress indicators.
 
 `/beautiful_deck` is the operational skill version of those essays. You don't need to re-read them to invoke it — the skill handles the workflow — but the essays explain *why* the principles work.

--- a/.claude/skills/beautiful_deck/SKILL.md
+++ b/.claude/skills/beautiful_deck/SKILL.md
@@ -1,8 +1,16 @@
 ---
 name: beautiful_deck
-description: End-to-end beautiful Beamer deck creation. Designs an original Beamer theme tailored to a specific audience, restructures existing content via the Rhetoric of Decks (ethos / pathos / logos), generates figures and tables from R/Python/Stata code first, embeds code blocks in the deck, produces standalone walkthrough scripts, compiles to zero warnings, runs /tikz for visual collision cleanup, and dispatches a graphics-only audit agent for label and coordinate checks. Use when creating a presentation from scratch or restructuring existing content into a new beautiful deck.
+description: >-
+  End-to-end beautiful Beamer deck creation. Designs an original Beamer theme
+  tailored to a specific audience, restructures existing content via the
+  Rhetoric of Decks (ethos / pathos / logos), generates figures and tables from
+  R/Python/Stata code first, embeds code blocks in the deck, produces standalone
+  walkthrough scripts, compiles to zero warnings, runs /tikz for visual
+  collision cleanup, and dispatches a graphics-only audit agent for label and
+  coordinate checks. Use when creating a presentation from scratch or
+  restructuring existing content into a new beautiful deck.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task
-argument-hint: [content-path-or-description]
+argument-hint: "[audience] [content-path-or-description]"
 ---
 
 # Beautiful Deck
@@ -11,7 +19,7 @@ This skill implements Scott's full deck-creation pipeline. It is NOT just a comp
 
 Scott's philosophy: **a deck is a performance medium, not a document**. It must be beautiful, technically rigorous, smoothly paced (MB/MC equivalence across slides), and visually clean at the pixel level. Every element earns its presence. Every title is an assertion. Every figure carries one message.
 
-This skill is the orchestrator. It calls `/tikz` for visual cleanup, references `compiledeck`'s mechanical rules (preambles, palettes, TikZ measurement formulas), and dispatches sub-agents for rhetoric and graphics audits.
+This skill is the orchestrator. It calls `/tikz` for visual cleanup, draws on its own local reference files (preambles, palettes, TikZ measurement formulas, domain patterns, style preferences) in this skill directory, and dispatches sub-agents for rhetoric and graphics audits.
 
 ---
 
@@ -19,16 +27,13 @@ This skill is the orchestrator. It calls `/tikz` for visual cleanup, references 
 
 You MUST collect answers to these questions before generating a single slide. If the user hasn't provided them in the invocation, ask explicitly. Do not guess.
 
-### Q1: What is the source content?
-- A paper draft (`.tex`, `.pdf`, `.md`)
-- Existing lecture notes
-- An existing deck to be restructured
-- A description and you generate from scratch
-- A paper the user is reading (in which case: have they split-pdf'd it? If yes, read the summaries. If no, ask whether to split-pdf first.)
+### Q1: Who is the audience? (**HARD BLOCK — resolve before any other question**)
 
-### Q2: Who is the audience?
+Audience is the single decision that ripples through every other choice in this skill — the rhetorical balance, the aesthetic direction, the act proportions, the pedagogical pacing all depend on it. Resolve audience first; do not proceed to Q2 (source content), theme design, or anything else until audience is committed.
 
-Pick ONE and commit. Different audiences demand different rhetorical balances (per Aristotle). Cite this table verbatim when confirming with the user:
+**If audience is missing from the invocation, ask immediately.** Use the `AskUserQuestion` tool (if available) to present a structured picker with the 5 canonical buckets as choices plus "Other." If `AskUserQuestion` is not available, ask in plain text and present the 5 canonical buckets as a numbered list. Do not begin theme work, source-content discussion, or anything else until the user has answered.
+
+The 5 canonical buckets (cite this table verbatim when confirming with the user):
 
 | Context | Logos | Ethos | Pathos | Implications for the deck |
 |---|---|---|---|---|
@@ -38,11 +43,41 @@ Pick ONE and commit. Different audiences demand different rhetorical balances (p
 | **Working deck (for coauthors or future-self)** | 60% | 30% | 10% | Document choices, preserve uncertainty, more text allowed, rigor > polish |
 | **External non-academic (policy, media, industry)** | 30% | 25% | 45% | Storytelling, human impact, minimal jargon, visual impact |
 
+**If the user gives free-text audience description (or picks "Other"), map to the closest canonical bucket and confirm with the user before proceeding.** Use this mapping table as a guide:
+
+| Free-text the user might give | Maps to |
+|---|---|
+| "my advisor and one coauthor" | Working deck |
+| "intro economics class" / "undergrad lecture" | Teaching lecture |
+| "general public" / "media interview" | External non-academic |
+| "internal team" / "lab meeting" / "future-self" | Working deck |
+| "policy briefing" / "congressional staff" | External non-academic |
+| "NBER conference" / "AEA session" | Conference presentation |
+| "job market talk" / "research seminar" | Academic seminar |
+
+When confirming the mapping, be explicit: "Mapping your description '<user's free text>' to **<canonical bucket>** — does that match what you have in mind?"
+
+**Sub-specifier for External non-academic.** When the user picks (or maps to) external non-academic, the rhetorical spread within this bucket is wider than within any other bucket. Ask one follow-up before proceeding:
+
+> External non-academic — which sub-context?
+> - **General public / media** (maximum pathos, story-driven, minimum jargon)
+> - **Policy / government / advocacy** (evidence-driven, action-oriented, moderate jargon)
+> - **Industry / corporate** (decision-oriented, ROI framing, domain jargon OK)
+
+Why this bucket only: the other 4 buckets have natural sub-variants (undergrad vs. grad teaching; methods vs. applied seminar) but the rhetorical mix stays largely the same. External is the unique case where the *kind* of pathos shifts, not just the dose.
+
+### Q2: What is the source content?
+- A paper draft (`.tex`, `.pdf`, `.md`)
+- Existing lecture notes
+- An existing deck to be restructured
+- A description and you generate from scratch
+- A paper the user is reading (in which case: have they split-pdf'd it? If yes, read the summaries. If no, ask whether to split-pdf first.)
+
 ### Q3: What is the tone / aesthetic?
 
 Two paths. Pick ONE:
 
-**Path A: Scott's house style (Professional/Academic).** Use the Warm Professional palette from `~/.claude/skills/compiledeck/SKILL.md` (DeepNavy, Teal, WarmOrange, Gold). Scott uses this for outward-facing academic work.
+**Path A: Scott's house style (Professional/Academic).** Use `~/.claude/skills/beautiful_deck/preamble_warm_professional.tex`. This is a ready-to-copy house-style preamble for outward-facing academic work, not a default palette for every deck.
 
 **Path B: Original, audience-specific design.** You design something new — a palette, a frame-title style, a TikZ accent system — tuned to this specific audience. This is the default when Scott says "design for me an original Beamer style." Do NOT reuse a previous deck's theme. You are creating something new.
 
@@ -89,13 +124,15 @@ The goal is: something truly effective for *this* audience, *this* content, and 
 
 ### How to approach it
 
-**If Path A (Scott's house style):** Copy the Warm Professional preamble from `~/.claude/skills/compiledeck/SKILL.md` Step 3 — this IS Scott's house style and is not boilerplate for outward-facing academic work. Proceed to Step 2.
+**If Path A (Scott's house style):** Copy the Warm Professional preamble from `~/.claude/skills/beautiful_deck/preamble_warm_professional.tex` — this IS Scott's house style and is not boilerplate for outward-facing academic work. Proceed to Step 2. Do not use this file as inspiration for Path B unless the user explicitly asks for a deck in that house style.
 
 **If Path B (original design — the default when Scott says "design for me an original Beamer style"):** You are designing an original aesthetic. Follow this process:
 
+Before implementing either path, read `~/.claude/skills/beautiful_deck/style_preferences.md`. Treat it as user-specific stylistic guidance only: it should shape persistent visual preferences such as slide-header treatments, but it does not override audience fit, content needs, or the rhetorical principles in `rhetoric_of_decks.md`.
+
 ### 1.1 Palette construction
 
-Pick a core accent (one color, not an ensemble). This is the emotional anchor of the deck. Examples that have worked:
+Pick a core accent (one color, not an ensemble). This is the emotional anchor of the deck. The examples below illustrate audience-to-color reasoning; they are not a house palette to reuse by default.
 
 | Audience | Core accent | Why |
 |---|---|---|
@@ -124,7 +161,7 @@ If bullets appear at all, use a single `\tikz\fill` circle in the core accent, s
 
 ### 1.4 Section dividers
 
-Full-bleed dark background (core accent or a dark neutral), white text, one large label centered. Use `\transitionslide{Title}{Subtitle}` pattern from `compiledeck/SKILL.md`. This creates the "deck breathes" rhythm — a moment of rest between sections.
+Full-bleed dark background (core accent or a dark neutral), white text, one large label centered. Use `\transitionslide{Title}{Subtitle}` pattern defined in `preamble_warm_professional.tex`. This creates the "deck breathes" rhythm — a moment of rest between sections.
 
 ### 1.5 Typography
 
@@ -174,7 +211,7 @@ Every deck has three acts. The proportions depend on audience (see Q2 table).
 
 **Act I — Tension (open + setup).** 2–4 slides.
 - Title slide.
-- Opening hook: a provocative question, a surprising statistic, or a concrete problem the audience recognizes. **NOT** an agenda, **NOT** "Today I'm going to talk about...", **NOT** a definition slide. See `presentations/rhetoric_of_decks.md` Part IV "The Opening" for examples.
+- Opening hook: a provocative question, a surprising statistic, or a concrete problem the audience recognizes. **NOT** an agenda, **NOT** "Today I'm going to talk about...", **NOT** a definition slide. See `rhetoric_of_decks.md` Part IV "The Opening" for examples.
 - The stakes: why does this matter? (This is where pathos lives.)
 - The roadmap (optional — only for teaching decks > 30 slides).
 
@@ -202,6 +239,21 @@ Every slide title must state a claim. Examples:
 | Implications | A smaller subsidy would have generated the same K/L response |
 
 If someone reads only the titles in sequence, they should understand the entire argument. Test this: write out just the titles. Does the sequence tell a coherent story? If not, your arc is broken.
+
+### Title length and line breaks
+
+Assertion titles should normally fit on one line. A title that wraps is usually trying to do body-text work. Rewrite it shorter before adding title-template machinery.
+
+Use this order:
+
+1. Keep the assertion, but remove setup words.
+2. Replace a clause with a sharper verb.
+3. Move qualifiers into the visual, caption, speaker notes, or the next slide.
+4. Split the slide if the full assertion needs multiple clauses.
+
+When line breaks are unavoidable, break only between words whenever possible. Do not rely on hyphenating or splitting a word across lines to make a title or body text fit; rewrite, resize the specific element, or change the layout first.
+
+This applies everywhere text appears, including TikZ nodes, table cells, callout boxes, captions, and screenshot placeholders. Short labels are especially sensitive: a two-word label such as "paper extraction" may wrap between words, but an ordinary word like "paper" or "sessions" must not be split across lines. If a word breaks inside a constrained box, widen the box or column, shorten the phrase, reduce only that local font size, or redesign the layout.
 
 ### The outline checkpoint
 
@@ -313,7 +365,7 @@ Work slide by slide, but also slide-sequence by slide-sequence. For each slide, 
 
 1. Re-read the outline to confirm this slide's role in the arc.
 2. **Check the pedagogical movement within the section.** Where are we in the Narrative → Application → Picture → Codeblock → Technical sequence? If we are writing a technical slide, confirm that the preceding slides have already delivered the story, the application, the picture, and (if relevant) the code. If they have not, back up and write those slides first. Never let the technical arrive before the intuition.
-3. Write the title as an assertion.
+3. Write the title as an assertion that fits on one line unless there is a deliberate exception.
 4. Pick ONE visual element: a figure, an equation, a diagram, a single statistic, a code block. Not two.
 5. Add minimal supporting text — a labeled setup ("From the FOC:", "Step 1:") or ONE concluding line. NEVER a wall of sentences.
 6. Check: can someone in the back row read every character? If not, cut text or increase font.
@@ -321,6 +373,8 @@ Work slide by slide, but also slide-sequence by slide-sequence. For each slide, 
 ### 4.2 The hard rules (no exceptions)
 
 - **One idea per slide.** Two max for inseparable contrasts.
+- **One-line assertion titles by default.** If a title wraps, rewrite it shorter before engineering around the wrap.
+- **Do not split words across lines when avoidable.** Hyphenated or broken words are a last resort; prefer rewriting, resizing the specific element, or changing layout. This includes TikZ nodes and table cells, not just prose text.
 - **No wall of sentences.** If you catch yourself writing a sentence that narrates what the audience can see, delete it.
 - **No bullet lists by default.** Find the structure (sequence, contrast, hierarchy, causal chain) and make it visible with layout.
 - **No decoration without function.** Stock photos, clip art, decorative icons — delete.
@@ -490,15 +544,17 @@ Apply all fixes the skill suggests, then recompile. Go back to Step 5 if any new
 
 Dispatch a sub-agent (via the Task tool) to evaluate the deck against the Rhetoric of Decks principles. Give it the following task prompt:
 
-> You are Referee 2 in rhetoric-review mode. Audit the Beamer deck at `<deck>.tex` and its compiled PDF at `<deck>.pdf` against the principles in `~/mixtapetools/presentations/rhetoric_of_decks.md`. Check specifically:
+> You are Referee 2 in rhetoric-review mode. Audit the Beamer deck at `<deck>.tex` and its compiled PDF at `<deck>.pdf` against the principles in `~/.claude/skills/beautiful_deck/rhetoric_of_decks.md`. Check specifically:
 >
 > 1. **Titles are assertions.** Read the titles in sequence. Do they tell a coherent story? List any title that is a label rather than an assertion, with a suggested rewrite.
-> 2. **One idea per slide.** List any slide with two or more competing ideas.
-> 3. **No wall of sentences.** List any slide with more than two prose sentences stacked vertically.
-> 4. **MB/MC equivalence.** Rate each slide's density on a 1–5 scale. Flag outliers (slides that are dramatically denser or sparser than their neighbors).
-> 5. **Narrative arc.** Does the deck have a clear Setup / Development / Resolution structure? Does the opening hook and does the closing linger?
-> 6. **Devil's Advocate.** Is there a slide addressing the strongest objection? If the context is academic or external, this is required.
-> 7. **Audience fit.** Does the rhetorical balance (ethos / pathos / logos) match the audience declared at Step 0?
+> 2. **Title line discipline.** Flag assertion titles that wrap or are likely to wrap. Suggest shorter one-line rewrites. Also flag avoidable word breaks or hyphenation used only to make text fit.
+> 3. **One idea per slide.** List any slide with two or more competing ideas.
+> 4. **No wall of sentences.** List any slide with more than two prose sentences stacked vertically.
+> 5. **Microtext fit.** Check TikZ nodes, table cells, callout boxes, captions, and placeholders for ordinary words split across lines. Suggest wider boxes/columns, shorter phrases, local font changes, or layout changes.
+> 6. **MB/MC equivalence.** Rate each slide's density on a 1–5 scale. Flag outliers (slides that are dramatically denser or sparser than their neighbors).
+> 7. **Narrative arc.** Does the deck have a clear Setup / Development / Resolution structure? Does the opening hook and does the closing linger?
+> 8. **Devil's Advocate.** Is there a slide addressing the strongest objection? If the context is academic or external, this is required.
+> 9. **Audience fit.** Does the rhetorical balance (ethos / pathos / logos) match the audience declared at Step 0?
 >
 > Return a structured report with numbered concerns and suggested rewrites. Do NOT modify the deck source — only diagnose. The main agent will apply fixes.
 
@@ -578,7 +634,7 @@ Report to the user:
 
 ---
 
-## Reference: The Three Laws (per `presentations/rhetoric_of_decks.md`)
+## Reference: The Three Laws (per `rhetoric_of_decks.md`)
 
 These are the constants that hold across every audience, every aesthetic, every deck. Read them once and internalize:
 
@@ -586,7 +642,7 @@ These are the constants that hold across every audience, every aesthetic, every 
 2. **Cognitive load is the enemy.** One idea per slide. Two max for inseparable contrasts. If you need "also" or "additionally," you need a new slide.
 3. **The slide serves the spoken word.** The slide is the visual anchor for what you say — not what you say. If your slides can be understood without you speaking, you have written a document and called it a presentation.
 
-## Reference: The Aristotelian triad (per `presentations/rhetoric_of_decks.md` Part II)
+## Reference: The Aristotelian triad (per `rhetoric_of_decks.md` Part II)
 
 - **Ethos (credibility).** The audience asks: *Why should I trust this person?* Ethos lives in methodology slides, Devil's Advocate slides, honest scorecards, acknowledgment of limitations. Admitting weakness builds credibility.
 - **Pathos (emotion).** The audience asks: *Why should I care?* Pathos lives in opening hooks, stakes, human impact, aspiration. Pathos without logos is demagoguery.
@@ -598,15 +654,24 @@ The rhetorical balance depends on the audience — see Q2 in Step 0.
 
 ## Full Philosophy Reference
 
-For the complete essay behind these principles:
-- `~/mixtapetools/presentations/rhetoric_of_decks.md` — the condensed operational version
-- `~/mixtapetools/presentations/rhetoric_of_decks_full_essay.md` — the 600-line intellectual genealogy from Aristotle through LLMs
+For the complete essay behind these principles, all in this skill directory:
+- `rhetoric_of_decks.md` — the condensed operational version
+- `rhetoric_of_decks_full_essay.md` — the 600-line intellectual genealogy from Aristotle through LLMs
+- `style_preferences.md` — user-specific stylistic defaults that persist across decks; separate from rhetorical principles.
 
 This skill operationalizes those essays. You don't need to re-read them to execute the workflow — just follow the steps above.
 
+## Local reference files
+
+All in this skill directory (`~/.claude/skills/beautiful_deck/`):
+
+- `preamble_warm_professional.tex` — Scott's house-style Beamer preamble (palette, fonts, footline, `\transitionslide` macro). Copy verbatim for Path A decks.
+- `palette_reference.md` — alternative palettes with selection guidance for Path B (original-design) decks.
+- `domain_patterns.md` — detailed structural patterns by audience (academic seminar, teaching lecture, working deck, etc.).
+- `~/.claude/skills/tikz/tikz_rules.md` — measurement-based collision-prevention rules (lives in the `tikz` skill folder; this skill **depends on `/tikz` being installed**). READ before writing any TikZ figure (Step 4.4).
+
 ## Supporting skills
 
-- `compiledeck` — the mechanical compile loop, preamble templates, palette reference, TikZ rules. `beautiful_deck` references it for these pieces rather than duplicating them.
 - `tikz` — the measurement-based visual collision audit. Invoked at Step 6.
 - `referee2` — the full five-audit protocol. `beautiful_deck` uses its rhetoric-audit logic in Step 7.
 - `split-pdf` — if the source content is a paper the user is reading, split it first and work from the summaries.

--- a/.claude/skills/beautiful_deck/domain_patterns.md
+++ b/.claude/skills/beautiful_deck/domain_patterns.md
@@ -1,0 +1,113 @@
+# Domain-Specific Deck Patterns
+
+## Academic Seminar (60-90 minutes, critical audience)
+
+### Recommended structure
+1. **Title slide**
+2. **The Puzzle** — one surprising fact or unanswered question. NOT "Motivation" with bullets.
+3. **What This Paper Does** — one slide, three contributions max
+4. **Related Literature** — why existing work is insufficient (not a list of papers)
+5. **Data and Setting** — show the data visually, not just describe it
+6. **Identification Strategy** — show the variation: a map, a timeline, an event study
+7. **Main Results** — one coefficient prominent, supporting info subordinate
+8. **Robustness** — key checks only. Full battery in appendix.
+9. **Devil's Advocate** — strongest objection + your response. Builds credibility.
+10. **Implications**
+11. **Closing** — one takeaway, not "Questions?"
+
+### Domain-specific rules
+- Lead with the QUESTION, not the literature
+- Identification strategy appears by slide 6 — skeptics want it early
+- Regression tables: highlight 1-2 coefficients, not the full table
+- Acknowledge limitations BEFORE Q&A — preempt Referee 2
+- Every title is an assertion: "Policy X increased Y by Z%"
+- Figures: readable from back row, treatment date marked, pre/post distinguished, key pattern annotated, confidence intervals shaded, title states the claim
+
+---
+
+## Teaching Lecture (50-75 minutes, learners)
+
+### How this differs from a seminar
+- **Clarity over compression** — more text per slide is acceptable because students take notes from slides
+- **Repetition is OK** — learning requires revisiting concepts
+- **Progressive revelation** — use `\pause` (Beamer overlays) for step-by-step derivations
+- **Definitions get their own slides** with block environments
+- **"Why does this matter?"** should appear frequently
+
+### Domain-specific rules
+- Font size floor is 18pt (lower than seminars because students sit closer)
+- Bullet points are acceptable for lists of properties, axioms, or steps
+- Show derivations step by step, not just final results
+- Include worked examples
+- Proofs use `align` environments revealed step by step with `\pause`
+
+---
+
+## Working Deck (coauthors, variable length)
+
+### How this differs from external
+- MORE detail is acceptable and expected
+- Document choices: "We chose X over Y because..."
+- Preserve uncertainty: "This could be Z but we haven't verified"
+- Flag unknowns explicitly with a consistent visual marker (e.g., a colored box)
+- Include data quality notes, merge diagnostics, sample construction details
+- Regression tables can be fuller — coauthors will scrutinize
+- Still follow visual hierarchy — dense does NOT mean ugly
+
+### Domain-specific rules
+- Titles still assert, but can be more technical
+- Include appendix slides with backup analyses
+- Date everything — assume forgotten context when revisited later
+- Include the "why" behind methodological decisions
+
+---
+
+## The Dual Audience Problem
+
+All decks increasingly circulate beyond their live audience. Strategies:
+- **Assertion titles** carry the argument for readers who skim
+- **Figures should be self-interpreting** — title, labels, annotations, source notes
+- **Footnotes** in small text provide context for later readers
+- **Appendix slides** after `\appendix` for backup material
+
+---
+
+## Opening and Closing Patterns
+
+### Openings that work
+- **The surprising number**: "In 2024, 47% of..." (big, centered, no decoration)
+- **The puzzle**: "Why did X happen when theory predicts Y?"
+- **The provocative claim**: "Everything we thought about Z is wrong."
+- **The human story**: "When Maria arrived at the clinic..." (then zoom out to data)
+
+### Openings that fail
+- "Motivation" with four bullet points
+- "Outline" listing every section
+- "Thank you for inviting me to speak"
+
+### Closings that work
+- One sentence the audience will remember tomorrow
+- A call to action or implication for their work
+- A return to the opening puzzle, now resolved
+
+### Closings that fail
+- "Questions?"
+- "Thank you!"
+- A summary slide restating every finding
+
+---
+
+## The Devil's Advocate Slide
+
+This is the most underused persuasion technique in academic presentations. It works because it builds credibility (ethos) through transparency:
+
+1. State the strongest objection to your argument
+2. Acknowledge what makes it compelling
+3. Explain why it doesn't hold, or how you've addressed it
+
+Format:
+> "A skeptic would say: [strongest objection]"
+> "This is a fair concern because [why it's reasonable]"
+> "Here is how we address it: [your response]"
+
+This should appear BEFORE Q&A, not as a response to it.

--- a/.claude/skills/beautiful_deck/palette_reference.md
+++ b/.claude/skills/beautiful_deck/palette_reference.md
@@ -1,0 +1,97 @@
+# Palette Reference
+
+Four palettes extracted from real decks. Use as-is or as inspiration for new designs.
+
+---
+
+## Warm Professional (Default)
+*Source: rhetoric_of_decks.tex*
+
+Best for: Academic seminars, conference talks, professional audiences.
+
+```latex
+\definecolor{DeepNavy}{HTML}{2E4057}
+\definecolor{Teal}{HTML}{048A81}
+\definecolor{WarmOrange}{HTML}{E85D04}
+\definecolor{SoftPurple}{HTML}{9D4EDD}
+\definecolor{WarmGray}{HTML}{6C757D}
+\definecolor{LightGray}{HTML}{E9ECEF}
+\definecolor{Cream}{HTML}{FBF8F1}
+\definecolor{DeepRed}{HTML}{D62828}
+\definecolor{Gold}{HTML}{D4A03A}
+\definecolor{SoftWhite}{HTML}{FAFAFA}
+```
+
+---
+
+## Bold Modernist
+*Source: workflow_deck.tex*
+
+Best for: Internal presentations, Substack content, talks where energy matters.
+
+```latex
+\definecolor{Midnight}{HTML}{1A1A2E}
+\definecolor{DeepBlue}{HTML}{16213E}
+\definecolor{RoyalBlue}{HTML}{0F3460}
+\definecolor{Coral}{HTML}{E94560}
+\definecolor{Sunset}{HTML}{F39C12}
+\definecolor{Mint}{HTML}{1ABC9C}
+\definecolor{Lavender}{HTML}{9B59B6}
+\definecolor{SoftGray}{HTML}{BDC3C7}
+\definecolor{LightGray}{HTML}{ECF0F1}
+\definecolor{CloudWhite}{HTML}{FAFBFC}
+\definecolor{Charcoal}{HTML}{2C3E50}
+```
+
+---
+
+## Warm Modernist
+*Source: insights_deck.tex*
+
+Best for: Personal projects, Substack decks, earth-toned storytelling.
+
+```latex
+\definecolor{Walnut}{HTML}{3D2B1F}
+\definecolor{Terracotta}{HTML}{C05746}
+\definecolor{Amber}{HTML}{D4954A}
+\definecolor{Forest}{HTML}{2D5F3E}
+\definecolor{Slate}{HTML}{4A6274}
+\definecolor{Cream}{HTML}{FAF5EE}
+\definecolor{Rose}{HTML}{C97B84}
+\definecolor{LightSand}{HTML}{F0E6D3}
+\definecolor{WarmGray}{HTML}{8B7D6B}
+\definecolor{DeepWalnut}{HTML}{2A1D14}
+```
+
+---
+
+## Academic Muted
+*Source: gov2001_probability.tex*
+
+Best for: University courses, formal academic house style, math-heavy content.
+
+```latex
+\definecolor{HarvardCrimson}{HTML}{A51C30}
+\definecolor{Slate}{HTML}{4A5568}
+\definecolor{Charcoal}{HTML}{2D3748}
+\definecolor{Forest}{HTML}{276749}
+\definecolor{Ocean}{HTML}{2B6CB0}
+\definecolor{WarmGray}{HTML}{718096}
+\definecolor{CreamWhite}{HTML}{FFFAF0}
+\definecolor{LightGray}{HTML}{F7FAFC}
+```
+
+---
+
+## Selection Guide
+
+| Context | Recommended palette |
+|---------|-------------------|
+| Academic seminar | Warm Professional or Academic Muted |
+| Teaching lecture | Warm Professional |
+| Working deck (coauthors) | Any — choose based on mood |
+| Substack / public content | Warm Modernist or Bold Modernist |
+| Conference keynote | Warm Professional |
+| Job market talk | Academic Muted |
+
+When the user requests "colorful" or "expressive": create something NEW each time, using these palettes as mood inspiration, not templates. Aim for 10-12 colors with warm undertones.

--- a/.claude/skills/beautiful_deck/preamble_warm_professional.tex
+++ b/.claude/skills/beautiful_deck/preamble_warm_professional.tex
@@ -1,0 +1,85 @@
+% Warm Professional Beamer preamble
+% Scott's house style — outward-facing academic decks.
+% Copy this verbatim into a new deck's .tex (or `\input` it).
+
+\documentclass[aspectratio=169,11pt]{beamer}
+
+% Packages
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{graphicx}
+\usepackage{tikz}
+\usepackage{pgfplots}
+\usepackage{xcolor}
+\usepackage{ragged2e}
+\usepackage{colortbl}
+\usepackage{array}
+\usepackage{hyperref}
+\usepackage{adjustbox}
+
+\usetikzlibrary{shapes.geometric, arrows.meta, positioning, calc,
+                backgrounds, decorations.pathreplacing, shadows, fadings}
+\pgfplotsset{compat=1.18}
+
+% --- Color Palette: Warm Professional ---
+\definecolor{DeepNavy}{HTML}{2E4057}
+\definecolor{Teal}{HTML}{048A81}
+\definecolor{WarmOrange}{HTML}{E85D04}
+\definecolor{SoftPurple}{HTML}{9D4EDD}
+\definecolor{WarmGray}{HTML}{6C757D}
+\definecolor{LightGray}{HTML}{E9ECEF}
+\definecolor{Cream}{HTML}{FBF8F1}
+\definecolor{DeepRed}{HTML}{D62828}
+\definecolor{Gold}{HTML}{D4A03A}
+\definecolor{SoftWhite}{HTML}{FAFAFA}
+
+% Beamer colors
+\setbeamercolor{normal text}{fg=DeepNavy, bg=SoftWhite}
+\setbeamercolor{structure}{fg=DeepNavy}
+\setbeamercolor{alerted text}{fg=DeepRed}
+\setbeamercolor{example text}{fg=Teal}
+\setbeamercolor{frametitle}{fg=DeepNavy, bg=SoftWhite}
+\setbeamercolor{title}{fg=DeepNavy}
+\setbeamercolor{subtitle}{fg=WarmGray}
+\setbeamercolor{block title}{bg=DeepNavy, fg=SoftWhite}
+\setbeamercolor{block body}{bg=LightGray, fg=DeepNavy}
+\setbeamercolor{itemize item}{fg=WarmOrange}
+\setbeamercolor{itemize subitem}{fg=Gold}
+
+% Fonts
+\usefonttheme{professionalfonts}
+\setbeamerfont{title}{size=\huge, series=\bfseries}
+\setbeamerfont{frametitle}{size=\Large, series=\bfseries}
+
+% Strip chrome
+\setbeamertemplate{navigation symbols}{}
+\setbeamertemplate{headline}{}
+
+% Minimal footline
+\setbeamertemplate{footline}{%
+    \hfill
+    \begin{beamercolorbox}[wd=3cm,ht=2.5ex,dp=1ex,right,rightskip=0.6cm]{page number}
+        \usebeamercolor[fg]{WarmGray}\scriptsize\insertframenumber
+    \end{beamercolorbox}
+    \vspace{0.3cm}
+}
+
+% Bullets
+\setbeamertemplate{itemize item}{\footnotesize\raisebox{0.3ex}{\tikz\fill[WarmOrange] (0,0) circle (0.45ex);}}
+\setbeamertemplate{itemize subitem}{\footnotesize\raisebox{0.3ex}{\tikz\fill[Gold] (0,0) circle (0.35ex);}}
+
+% Custom commands
+% \transitionslide{Title}{Subtitle} — full-bleed dark transition between sections
+\newcommand{\transitionslide}[2]{%
+    {\setbeamercolor{normal text}{fg=SoftWhite,bg=DeepNavy}
+    \begin{frame}[plain]\vfill\begin{center}
+        {\huge\bfseries\textcolor{Gold}{#1}}\\[0.6cm]
+        {\large\textcolor{LightGray}{#2}}
+    \end{center}\vfill\end{frame}}
+}
+
+\graphicspath{{figures/}}

--- a/.claude/skills/beautiful_deck/rhetoric_of_decks.md
+++ b/.claude/skills/beautiful_deck/rhetoric_of_decks.md
@@ -1,0 +1,549 @@
+# The Rhetoric of Decks
+
+A framework for effective slide presentations in academic and professional contexts.
+
+---
+
+## The Fundamental Insight
+
+A slide deck is not a document. It is not a paper. It is not a memo. It is a *performance medium*—a visual accompaniment to a spoken argument. The moment you treat a deck as a standalone artifact, you have already failed.
+
+This distinction matters because it determines everything else: how much text you use, how you structure information, what you include and exclude, and how you think about your relationship to your audience.
+
+---
+
+## Part I: The Three Laws
+
+### Law 1: Beauty Is Function
+
+Beautiful slides are not decorated slides. Beauty in presentation is *clarity made visible*. A slide is beautiful when:
+
+- Every element earns its presence
+- Nothing distracts from the point
+- The eye knows where to go
+- The mind grasps the idea instantly
+
+Decoration without function is noise. A gradient that serves no purpose, a stock photo that illustrates nothing, an animation that delays comprehension—these are not design choices. They are failures.
+
+The most beautiful slide may be three words on a blank background.
+
+### Law 2: Cognitive Load Is the Enemy
+
+Your audience has limited working memory. Every slide competes with:
+
+- Their internal monologue
+- Their phone
+- Their email
+- Their lunch plans
+- The last slide they're still processing
+
+You are not fighting for their attention. You are fighting for their *cognitive capacity*. Every unnecessary word, every extraneous data point, every "just in case" inclusion steals bandwidth from your actual message.
+
+The formula is brutal:
+- Too many points → zero points retained
+- Dense text → nothing read
+- Complex charts → confusion, not insight
+
+One idea per slide. One. This is not a guideline. This is the law. Two ideas maximum if they form an inseparable contrast (e.g., "correct interpretation" vs. "wrong interpretation"). But if you find yourself writing "also" or "additionally" on a slide, you need a new slide. The test is simple: can you state the slide's point in one sentence? If you need two sentences, you need two slides.
+
+#### No Wall of Sentences
+
+A "wall of sentences" is what happens when a slide contains multiple prose sentences stacked vertically — three, four, five sentences of running text that could have come from a Word document. This is the single most common failure mode in academic presentations. It signals that the presenter has not done the work of distilling the idea.
+
+What a wall of sentences looks like:
+- "The treatment effect was significant at the 5% level. This suggests that the intervention had a meaningful impact. However, we should note that the confidence interval was wide. Further research is needed to confirm these findings."
+
+That belongs in a paper, not on a slide. On the slide, the equation or the CI plot does the work. The speaker provides the narrative. Text on the slide exists only to *label*, *set up*, or *structure* — never to *explain*.
+
+Acceptable text on slides:
+1. **A short labeled setup** introducing an equation or visual: "From the FOC:", "Step 1:", "Setup:"
+2. **A single concluding line** after the final visual element — at most ONE, and only if it adds information not in the title or visual
+3. **Structured content**: bullets, tables, labeled contrasts, numbered steps
+
+If you catch yourself writing a sentence that narrates what the audience can see, delete it. That sentence belongs in your mouth.
+
+### Law 3: The Slide Serves the Spoken Word
+
+The slide is not what you say. The slide is the *visual anchor* for what you say. It provides:
+
+- A focal point for attention
+- A memory hook for retention
+- Evidence to support your claim
+- A structural marker showing where you are in the argument
+
+Read the following sentence and understand it completely: *If your slides can be understood without you speaking, you have written a document and called it a presentation.*
+
+The corollary: if you must read your slides aloud, you have failed twice—once in slide design, once in preparation.
+
+---
+
+## Part II: The Aristotelian Foundation
+
+Aristotle identified three modes of persuasion 2,400 years ago. They remain definitive.
+
+### Ethos (Credibility)
+
+The audience asks: *Why should I trust this person?*
+
+Ethos is established through:
+- Demonstrated competence (you've done your homework)
+- Transparency about limitations (you're not hiding weaknesses)
+- Alignment with audience values (you understand their world)
+- Acknowledged uncertainty (you distinguish what you know from what you assume)
+
+In decks, ethos appears as:
+- Process diagrams showing your methodology
+- Acknowledgment of alternative approaches you considered
+- The "Devil's Advocate" slide that shows you've stress-tested your thinking
+- Honest scorecards that rate yourself fairly, not generously
+
+The counterintuitive truth: *admitting weakness builds credibility*. The presenter who says "this approach has three significant limitations" is more trusted than the one who claims perfection.
+
+### Pathos (Emotion)
+
+The audience asks: *Why should I care?*
+
+Pathos is not manipulation. It is the recognition that humans are not purely rational. We care about:
+- Problems that affect us
+- Stories about people like us
+- Frustrations we've experienced
+- Aspirations we hold
+
+In decks, pathos appears as:
+- Opening with a problem the audience recognizes ("You've probably experienced...")
+- Validating frustrations ("You were right to be frustrated")
+- Connecting data to human impact
+- Showing what success looks like (not just avoiding failure)
+
+The danger: pathos without logos is demagoguery. "This is so important!" without evidence produces skepticism, not buy-in.
+
+### Logos (Logic)
+
+The audience asks: *Does this make sense?*
+
+Logos is the rational structure of your argument:
+- Clear causal claims
+- Evidence supporting those claims
+- Logical progression from premise to conclusion
+- Acknowledgment of counterarguments
+
+In decks, logos appears as:
+- Data visualizations that reveal patterns
+- Comparison tables that structure choices
+- Before/after examples that demonstrate impact
+- The logical flow from "here's the problem" to "here's why this solution works"
+
+The danger: logos without pathos is a lecture. "Here are 47 facts" produces disengagement, not conviction.
+
+### The Balance
+
+No formula exists. Context determines balance:
+
+| Context | Emphasis |
+|---------|----------|
+| Legal brief | Logos 70%, Ethos 25%, Pathos 5% |
+| Eulogy | Pathos 60%, Ethos 30%, Logos 10% |
+| Product pitch | Pathos 40%, Logos 35%, Ethos 25% |
+| Technical review | Logos 50%, Ethos 40%, Pathos 10% |
+| Academic seminar | Logos 45%, Pathos 35%, Ethos 20% |
+
+The key: *audience analysis determines the balance*. Who are they? What do they need? What are they skeptical of? What do they already believe?
+
+---
+
+## Part III: Titles Are Assertions, Not Labels
+
+Slide titles carry the argument. They are not labels—they are claims.
+
+**Weak**: "Results"
+**Strong**: "Treatment increased distance by 61 miles on average"
+
+**Weak**: "Literature Review"
+**Strong**: "Prior work ignores the supply-side margin"
+
+**Weak**: "Methods"
+**Strong**: "We exploit county-level variation in clinic closures"
+
+If someone reads only your slide titles in sequence, they should understand your argument. The titles *are* the argument. Everything else is evidence and elaboration.
+
+---
+
+## Part IV: Narrative Structure
+
+### The Arc
+
+Every presentation tells a story. The story has three acts:
+
+**Act I: Problem (Tension)**
+- Establish the status quo
+- Introduce the disruption/challenge/question
+- Make the audience feel the problem
+
+**Act II: Investigation (Development)**
+- Show what you tried
+- Present what you learned
+- Build the logical case
+
+**Act III: Resolution (Release)**
+- Deliver the insight
+- Show the implications
+- Provide the call to action
+
+This is not optional structure. It is how human brains process information. Fight it and lose your audience. Use it and carry them with you.
+
+### The Pyramid Principle
+
+Barbara Minto figured this out for consulting documents, but it applies to decks: **Lead with the conclusion. Then support it.**
+
+Humans are not suspense novels. We don't want to follow your reasoning step by step and arrive at the punchline. We want the punchline, and then we want to understand why it's true.
+
+Structure:
+1. Here's what I'm going to tell you (the claim)
+2. Here's the evidence for it
+3. Here's why it matters
+
+Not:
+1. Here's some background
+2. Here's some more background
+3. Here's a complication
+4. Here's my analysis
+5. Here's my finding (finally)
+
+**Exception for teaching:** When the pedagogical goal is for students to understand the *reasoning*, not just the *conclusion*, the pyramid inverts. You walk through the logic step by step and arrive at the result together. The student who sees "OLS is BLUE" on slide 2 and then watches you prove it has a fundamentally different learning experience from the student who works through the proof and discovers the result. Both are valid. Context determines which is appropriate.
+
+### The Opening
+
+The first slide after your title is the most important. It must:
+- Grab attention
+- Establish stakes
+- Preview the journey
+
+Bad openings:
+- "Today I'm going to talk about..." (boring, passive)
+- Agenda slides with 12 items (overwhelming)
+- Definition slides (academic, pedantic)
+
+Good openings:
+- A provocative question
+- A surprising statistic
+- A concrete problem the audience recognizes
+- A bold claim you'll defend
+
+The audience decides in the first 60 seconds whether to pay attention. Win or lose in that window.
+
+### The Closing
+
+The last slide lingers. It determines what people remember.
+
+Bad closings:
+- "Questions?" (lazy, generic)
+- Summary slides repeating everything verbatim (redundant in short talks; appropriate in lectures)
+- Thank you slides (wasted real estate)
+
+Good closings:
+- A single, memorable takeaway
+- A concrete call to action
+- A question that provokes continued thought
+- A return to the opening, now resolved
+
+If you had to reduce your entire presentation to one sentence, what would it be? That sentence belongs on your closing slide.
+
+---
+
+## Part V: Visual Grammar
+
+### Hierarchy
+
+Not all information is equal. Your visual design must reflect this:
+
+- **Primary**: The one thing you want remembered (large, prominent, above the fold)
+- **Secondary**: Supporting evidence (smaller, subordinate)
+- **Tertiary**: Context and sourcing (smallest, footer)
+
+If everything is emphasized, nothing is emphasized.
+
+### Bullets Are a Default, and Defaults Are Dangerous
+
+Bullet points are the most common slide structure in academia. That alone should make you suspicious. A list of bullets *can* mean "I couldn't figure out the relationship between these ideas, so I'm just listing them."
+
+But genuinely parallel items of equal weight — assumptions for a theorem, properties of an estimator, a checklist of conditions — are what bullets were designed for. The failure is not using bullets. The failure is using bullets without asking whether a better structure exists.
+
+Usually, there's a structure hiding in your bullets:
+
+- A sequence (first, then, finally)
+- A contrast (on one hand, on the other)
+- A hierarchy (the main point, and supporting details)
+- A causal chain (because of X, we see Y)
+
+Find the structure. Make it visible. Use layout, not bullets.
+
+### White Space
+
+Empty space is not wasted space. It is:
+- Rest for the eye
+- Emphasis for the content
+- Confidence in your message
+
+Crowded slides signal fear—fear that you'll leave something out, fear that the audience won't get it. White space signals confidence. You know what matters.
+
+### Typography
+
+Rules:
+- Minimum 24pt for body text (18pt absolute floor)
+- Maximum two fonts (one for headings, one for body)
+- Sans-serif for projection (serif details disappear at distance)
+- Never justify text (ragged right is easier to read)
+
+The test: can someone in the back row read this without straining? If not, you have too much text.
+
+### Data Visualization
+
+Charts are arguments, not decorations. Every chart must answer: *what am I supposed to conclude from this?*
+
+Principles:
+- One message per chart
+- Remove chartjunk (3D effects, excessive gridlines, decorative elements)
+- Label directly (no legends requiring eye movement)
+- Use color to highlight the key comparison
+
+A common failure: showing a dense regression table and saying "as you can see..." No. They cannot see. You have 45 seconds before they give up.
+
+What to do instead:
+- Highlight the one or two coefficients that matter
+- Use color or boxes to draw the eye
+- State the finding verbally while pointing
+- Consider whether you need the full table, or just the key results visualized
+
+If you can't explain what the chart proves in one sentence, the chart is too complex.
+
+### Mathematical Content
+
+Equations are visual elements. They follow the same rules as charts: one message per equation display, label what matters, remove what doesn't advance the argument.
+
+Principles for mathematical slides:
+- **One equation per conceptual step.** If you're deriving a result, each algebraic manipulation should be its own slide or its own clearly separated block. Don't show six lines of algebra simultaneously.
+- **Annotate the key term.** If an equation has five terms but the insight lives in one of them, use color, boxing, or an arrow to direct attention. The audience should not have to parse the entire expression to find your point.
+- **Align related equations.** When showing a sequence of expressions (e.g., expanding a sum, applying an operator), align on the equals sign or the operator that changes. Misaligned equations force the eye to hunt for what changed.
+- **Name your objects.** Don't assume the audience tracks notation across slides. A brief label ("where $\bar{x}$ is the sample mean") costs almost nothing and prevents the cascading confusion of lost notation.
+
+---
+
+## Part VI: The Economics of Attention
+
+### The Optimization Problem
+
+Here's a framework that makes the intuition precise: **optimal rhetoric equalizes the marginal benefit to marginal cost ratio across all slides**.
+
+Let MB be the marginal benefit of adding information to a slide—the incremental insight, evidence, or emotional resonance gained. Let MC be the marginal cost—the cognitive load imposed, the attention demanded, the risk of overwhelming the audience.
+
+The optimal deck satisfies:
+
+$$\frac{MB_1}{MC_1} = \frac{MB_2}{MC_2} = \cdots = \frac{MB_n}{MC_n}$$
+
+When this condition fails—when one slide is overloaded while another is sparse—you've misallocated your audience's attention budget.
+
+### What This Means in Practice
+
+**Overloaded slides** (MB/MC too low):
+- Text running into the footer
+- Multiple competing ideas
+- Charts with too many series
+- The audience gives up before extracting value
+
+**Underloaded slides** (MB/MC too high):
+- A single word that could support a sentence
+- Wasted opportunity to reinforce the point
+- The audience's attention is captured but not used
+
+**The audit**: Walk through your deck and ask of each slide: "If I added one more element, would the benefit justify the cognitive cost? If I removed one element, would I lose more than I'd gain in clarity?" When every slide answers "I'm at the margin," you're optimized.
+
+### The Deeper Philosophy
+
+**Great decks respect the audience as a scarce resource.**
+
+The audience's attention is not infinite. It is not even large. It is a small, precious reservoir that depletes with every demand you make. The great presenter treats attention the way a desert traveler treats water.
+
+**Great decks achieve compression without loss.**
+
+Information theory tells us that compression is possible only when redundancy exists. The great deck identifies what is truly essential and strips away the redundant, the decorative, the "nice to have." A haiku is compressed. A grunt is merely short.
+
+**Great decks create rhythm.**
+
+The equalization principle implies variation. Dense, technical slides demand lighter slides that follow. A complex argument needs a moment of rest. The deck *breathes*.
+
+**Great decks know that omission is a choice, not a failure.**
+
+The mediocre presenter fears leaving something out. "What if they need this? What if they ask?" So they include everything, and by including everything, communicate nothing.
+
+The great presenter knows that choosing *not* to include something is as much a rhetorical act as choosing to include it. The blank space speaks. The omission says: "I respect you enough to leave room for your own intelligence."
+
+---
+
+## Part VII: The Devil's Advocate
+
+This is the secret weapon.
+
+Before presenting your argument, present its strongest critique. Show the audience:
+- The objections you anticipated
+- The weaknesses you acknowledge
+- The mitigations you've developed
+
+This accomplishes three things:
+1. **Ethos**: You've done the hard thinking
+2. **Preemption**: You've addressed objections before they're raised
+3. **Credibility**: You're not hiding from problems
+
+The format:
+- "A skeptic would say..."
+- "Here's what could go wrong..."
+- "The strongest objection is..."
+
+Then: your response, your mitigation, your acknowledgment of residual risk.
+
+Audiences trust presenters who show their skeptics.
+
+---
+
+## Part VIII: Context-Specific Applications
+
+### Academic Seminar Decks
+
+For research presentations:
+
+- **Lead with the question, not the literature**: What puzzle are you solving?
+- **Identification strategy early**: Skeptical academics want to know your source of variation
+- **One coefficient at a time**: Don't show full regression tables; show the estimate that matters
+- **Acknowledge limitations before Q&A**: Preempt Referee 2
+
+### Teaching Decks
+
+Teaching decks deserve special attention because the audience constraints are fundamentally different from seminar or pitch contexts.
+
+**Students are not peers.** They are encountering your ideas for the first time. The cognitive load budget is smaller per idea, and the cost of confusion is higher. The core rules still apply — one idea per slide, no wall of sentences, titles are assertions — but the implementation shifts:
+
+- **More labeled setups are needed.** "From the definition of variance:", "Applying the expectation operator:", "Step 3 of 4:" — these signposts are not clutter in a teaching deck. They are load-bearing structure.
+- **Roadmap slides earn their place.** In a seminar, an agenda slide with eight items is overload. In a 75-minute lecture, a roadmap slide that says "We are here" helps students who got lost re-orient. Use them at transitions.
+- **The MB/MC calculus shifts.** A recap slide has near-zero marginal benefit in a seminar (the audience already knows). In a teaching deck, recap slides have high marginal benefit because repetition is how learning works. The optimal deck for teaching is less compressed than the optimal deck for persuasion.
+- **Worked examples are content, not filler.** Showing the algebra step by step is not violating "one idea per slide." The idea *is* the derivation. Each step can be its own slide if needed.
+- **Brevity < Clarity**: Don't compress at the cost of understanding.
+- **Show the reasoning**: Don't just show conclusions; show how you got there.
+
+### Working Decks (for collaborators)
+
+When working with collaborators:
+
+- **Document choices**: Explain why you chose A over B
+- **Preserve uncertainty**: Flag what's still unknown
+- **Enable iteration**: Make it easy to build on your work
+- **Show the math**: Colleagues can verify; clients need confidence
+
+The working deck prioritizes rigor over polish. It's a thinking tool, not a performance.
+
+### The Deck as Future Communication
+
+When making a deck for your future self—not for an audience, but as documentation:
+
+- Be more explicit than you would for live presentation
+- Include the "why" behind choices, not just the "what"
+- Write in complete thoughts where necessary
+- Date everything
+- Assume you'll have forgotten the context
+
+The deck becomes a letter to someone who shares your goals but not your current memory. Be kind to that person.
+
+---
+
+## Part IX: Common Failures
+
+### 1. Text Walls
+**Symptom**: Slides that could be printed as paragraphs.
+**Fix**: Extract the key phrase. Everything else is speaker notes or handouts.
+
+### 2. Burying the Lede
+**Symptom**: The key point appears on slide 15.
+**Fix**: State your conclusion on slide 2. Then prove it.
+
+### 3. Chartjunk
+**Symptom**: 3D bar charts with gradient fills and decorative axes.
+**Fix**: Remove elements until removing more would remove meaning.
+
+### 4. Agenda Overload
+**Symptom**: Opening agenda with 8-12 items.
+**Fix**: Three sections maximum. Or cut the agenda entirely.
+
+### 5. "Questions?" Ending
+**Symptom**: Final slide is generic "Questions?" or "Thank You."
+**Fix**: End with your key takeaway or call to action.
+
+### 6. Evidence-Free Claims
+**Symptom**: Assertions without support.
+**Fix**: Every claim gets a source. "According to..." or "This chart shows..."
+
+### 7. Decoration Without Function
+**Symptom**: Stock photos, clip art, decorative icons.
+**Fix**: Delete if it doesn't advance the argument. White space is better than noise.
+
+### 8. Anxiety Overload
+**Symptom**: Dense slides used as a security blanket.
+**Cause**: When you're nervous, you put more on slides. More text, more backup, more "just in case."
+**Fix**: Sparse slides force you to know your material. They make you the authority, not the slides.
+
+---
+
+## Part X: Process
+
+### Preparation Sequence
+
+1. **Define the takeaway**: What one thing must the audience remember?
+2. **Analyze the audience**: Who are they? What do they know? What do they doubt?
+3. **Outline the arc**: Problem → Investigation → Resolution
+4. **Draft ugly**: Get ideas down without design
+5. **Apply the laws**: One idea per slide, beauty is function, serve the spoken word
+6. **Add the skeptic**: Where will they object? Address it.
+7. **Cut ruthlessly**: When in doubt, delete
+8. **Practice aloud**: The slide supports speech, not vice versa
+
+### The Review Questions
+
+Before presenting, ask:
+
+- Can someone in the back row read every slide?
+- Does every slide advance the argument?
+- Is there only one idea per slide?
+- Have I acknowledged the strongest objection?
+- Will the audience know what to do when I'm done?
+- What's the one thing they'll remember tomorrow?
+
+If you can't answer these questions clearly, you're not ready.
+
+---
+
+## Conclusion: The Meta-Point
+
+This document is long. A deck on this topic would be short.
+
+That's the point.
+
+Writing *about* deck rhetoric requires explanation, nuance, and elaboration. *Practicing* deck rhetoric requires compression, selection, and restraint.
+
+The best deck on deck rhetoric would have perhaps twelve slides:
+1. Title
+2. The fundamental insight (decks are performance, not documents)
+3. Law 1: Beauty is function
+4. Law 2: Cognitive load is the enemy
+5. Law 3: The slide serves the spoken word
+6. The Aristotelian triad (one visual)
+7. The narrative arc (one visual)
+8. The Devil's Advocate
+9. One idea per slide
+10. Common failure (example)
+11. The preparation sequence
+12. Your takeaway: What will they remember?
+
+Everything else in this document would be spoken, not shown.
+
+That's the theory. Now apply it.
+
+---
+
+*This framework synthesizes tacit knowledge from academic seminars, consulting decks, and teaching presentations. The patterns exist. People who've seen enough decks internalize them without being able to articulate them. This is an attempt to articulate them.*

--- a/.claude/skills/beautiful_deck/rhetoric_of_decks_full_essay.md
+++ b/.claude/skills/beautiful_deck/rhetoric_of_decks_full_essay.md
@@ -1,0 +1,605 @@
+# The Rhetoric of Decks: A Theory of Sequential Persuasion in the Age of Artificial Intelligence
+
+---
+
+## I. What Is Rhetoric?
+
+Rhetoric is not ornament. It is not flourish, embellishment, or the art of making weak arguments sound strong. That caricature—rhetoric as manipulation, as sophistry, as spin—reflects a corruption of the term that would have puzzled its earliest theorists.
+
+Rhetoric, properly understood, is the study of how humans persuade one another. It asks: when communication succeeds, why does it succeed? When it fails, why does it fail? What makes one argument land and another fall flat, even when both are logically valid? These are not trivial questions. They sit at the intersection of psychology, epistemology, ethics, and aesthetics.
+
+The field emerges as a formal discipline in classical Greece, but its crystallization into systematic theory owes primarily to one figure: Aristotle of Stagira.
+
+### Aristotle and the Founding of Rhetoric
+
+Aristotle (384–322 BCE) came to rhetoric somewhat unexpectedly. His primary intellectual commitments lay elsewhere—in metaphysics, ethics, biology, logic, politics. He studied under Plato at the Academy for twenty years, later tutored Alexander the Great, and eventually founded his own school, the Lyceum. His surviving corpus spans dozens of treatises across nearly every domain of inquiry. He is, by any measure, among the most influential thinkers in human history.
+
+So why rhetoric? Why would a philosopher of such range turn his attention to persuasion?
+
+The answer lies in Aristotle's intellectual project. Unlike Plato, who often treated rhetoric with suspicion—viewing it as a tool for manipulating the ignorant—Aristotle recognized that persuasion was inescapable in human affairs. Courts required advocates. Assemblies required deliberation. Citizens required the capacity to evaluate arguments. If persuasion was unavoidable, then it could be studied, systematized, and improved. Rhetoric was not the enemy of philosophy; it was its necessary complement.
+
+In the *Rhetoric*, Aristotle defines his subject as "the faculty of observing in any given case the available means of persuasion." This is a capacious definition. It does not prescribe a single technique but rather opens an inquiry: what resources does a speaker have? How do they function? Under what conditions do they succeed?
+
+His answer organized the field for millennia. Persuasion, Aristotle argued, operates through three modes:
+
+**Ethos** (credibility): The audience asks, *why should I trust this speaker?* Ethos is established through demonstrated competence, apparent goodwill toward the audience, and moral character. It is not simply reputation brought to the speech but credibility constructed within it. A speaker who acknowledges uncertainty, who addresses counterarguments fairly, who demonstrates familiarity with the subject—this speaker earns trust through the performance itself.
+
+**Pathos** (emotion): The audience asks, *why should I care?* Pathos recognizes that humans are not purely rational calculators. We are moved by fear, hope, anger, sympathy, pride, shame. Aristotle catalogs these emotions in detail, analyzing their causes and conditions. The point is not that emotions should override reason but that reason disconnected from emotion rarely motivates action. The speaker must make the audience *feel* the stakes.
+
+**Logos** (argument): The audience asks, *does this make sense?* Logos encompasses the logical structure of the case—the evidence marshaled, the inferences drawn, the examples adduced. Aristotle distinguishes between formal demonstration (the province of logic proper) and rhetorical argument, which operates through enthymemes (compressed syllogisms that rely on audience beliefs) and examples (inductive generalizations). Logos is not everything, but without it, ethos and pathos become manipulation.
+
+The Aristotelian framework is notable for its balance. It neither dismisses emotion as irrational nor treats logic as sufficient. It recognizes that persuasion is contextual—that audiences differ, occasions differ, subjects differ—and that the effective speaker calibrates to circumstance.
+
+### Is Rhetoric Simply "A Way of Saying Things"?
+
+One might object that this elevates something trivial. Isn't rhetoric just style? Just presentation? Just the packaging rather than the substance?
+
+This objection misunderstands the nature of communication. There is no neutral transmission of ideas from one mind to another. Every act of communication involves selection (what to include, what to omit), arrangement (what order, what emphasis), and expression (what words, what tone, what medium). These choices are not incidental to meaning; they constitute it. The "same" argument presented differently is not, in fact, the same argument. It lands differently, persuades differently, is remembered differently.
+
+Rhetoric is the systematic study of these choices and their effects. It is not opposed to substance but is rather the study of how substance becomes persuasive. To dismiss rhetoric as "mere" style is to misunderstand both rhetoric and style.
+
+---
+
+## II. A History of Rhetoricians After Aristotle
+
+Aristotle established the field, but he did not complete it. Rhetoric continued to evolve through successive cultural contexts, each contributing new emphases and corrections.
+
+### Cicero and the Roman Tradition
+
+Marcus Tullius Cicero (106–43 BCE) adapted Greek rhetorical theory to Roman political and legal practice. His contributions were partly synthetic—he transmitted and organized Greek ideas—but also substantive. Cicero emphasized the education of the orator as a complete person: broadly learned, ethically grounded, practically experienced. For Cicero, rhetoric was inseparable from wisdom. The ideal orator was not a technician of persuasion but a statesman capable of moving citizens toward the good.
+
+Cicero also elaborated the five canons of rhetoric that would structure rhetorical education for centuries:
+
+1. **Invention** (*inventio*): discovering arguments
+2. **Arrangement** (*dispositio*): organizing material
+3. **Style** (*elocutio*): choosing words and figures
+4. **Memory** (*memoria*): retaining the speech
+5. **Delivery** (*pronuntiatio*): presenting through voice and gesture
+
+This framework acknowledged that rhetoric was not merely composition but performance—a recognition that would become newly relevant two thousand years later.
+
+### Quintilian and Pedagogy
+
+Quintilian (35–100 CE), a Roman educator, produced the *Institutio Oratoria*, a comprehensive treatise on rhetorical education. His emphasis was pedagogical: how do you train speakers from childhood through maturity? Quintilian's influence extended through the medieval period into the Renaissance, shaping curricula and ideals of educated speech. He reinforced the connection between rhetoric and moral formation—the orator as *vir bonus dicendi peritus*, the good person skilled in speaking.
+
+### Augustine and Sacred Rhetoric
+
+Augustine of Hippo (354–430 CE) represents a crucial transformation. As a convert from Manichaeism to Christianity, Augustine brought his training in classical rhetoric to the service of theology. In *De Doctrina Christiana* (On Christian Teaching), he argued that Christians should not abandon rhetoric simply because pagans had developed it. Truth deserves eloquence. If falsehood is presented persuasively, truth should be no less so.
+
+Augustine thus adapted Aristotelian and Ciceronian rhetoric for homiletics—the art of preaching. His contribution was to recognize that rhetoric serves ends beyond itself. The Christian preacher aims not merely to persuade but to illuminate, to convict, to transform. This teleological framing—rhetoric in service of transcendent purpose—would dominate medieval theory.
+
+### Medieval and Renaissance Developments
+
+Through the medieval period, rhetoric contracted in scope, often reduced to style and figures of speech while logic and dialectic claimed the argumentative terrain. The trivium—grammar, logic, rhetoric—placed rhetoric third, sometimes treating it as mere ornamentation.
+
+The Renaissance recovered fuller classical sources and with them a richer conception of rhetoric. Humanists like Erasmus and Vives restored rhetoric's connection to civic life, ethical formation, and the full range of human persuasion. The printing press, meanwhile, began to transform the rhetorical situation in ways the ancients could not have anticipated.
+
+### The Modern Period and Disciplinary Fragmentation
+
+From the seventeenth century forward, rhetoric's terrain was progressively colonized by other disciplines. Logic became formal and mathematical. Psychology claimed the study of emotion and cognition. Literary criticism claimed style. Political science claimed deliberation. Rhetoric, as a unified field, fragmented.
+
+Yet the core questions persisted. When the twentieth century saw renewed interest in rhetoric—through Kenneth Burke's dramatism, Chaim Perelman's "new rhetoric," and the emergence of composition studies—it was in part a recognition that no other discipline had adequately addressed the fundamental question: how does communication persuade?
+
+---
+
+## III. Technology and the Transformation of Persuasion
+
+Rhetorical theory developed in a particular technological context: oral performance before live audiences. The orator stood before the assembly, the jury, the congregation. Success required memory, presence, voice, gesture. The audience was physically present, unable to pause, rewind, or skim.
+
+Every subsequent technological shift has transformed the rhetorical situation, altering what is possible, what is expected, and what is effective.
+
+### Literacy and the Written Word
+
+The spread of literacy created audiences who could receive arguments in the speaker's absence. Writing permitted complexity impossible in oral performance—longer arguments, more intricate structures, precise quotation and citation. But it also eliminated the immediate feedback loop of live audience response. The writer must anticipate objections without seeing faces. Ethos must be established through text alone, without the charisma of presence.
+
+### The Printing Press
+
+Gutenberg's innovation (c. 1440) democratized textual reproduction, expanding potential audiences by orders of magnitude. Pamphlets, treatises, and eventually newspapers created publics that had never existed—readers who shared exposure to common texts without sharing physical space. This enabled new forms of political rhetoric (the pamphlet wars of the Reformation, the Federalist Papers) but also posed new challenges: how do you establish credibility with readers you will never meet?
+
+### Mass Literacy and Universal Education
+
+The nineteenth and twentieth centuries saw the progressive expansion of literacy to populations previously excluded: the working class, women, colonized peoples, racial minorities. Each expansion changed not just who could receive messages but who could produce them and what messages found audiences. The rhetorical landscape diversified.
+
+### Radio and Television
+
+Broadcasting introduced a paradox: mass intimacy. Franklin Roosevelt's fireside chats reached tens of millions, yet the medium created the impression of personal address. Television added visual presence, making appearance, gesture, and production values newly central. The Kennedy-Nixon debates of 1960 famously illustrated the medium's power: radio listeners thought Nixon won; television viewers favored Kennedy. Ethos became partly aesthetic.
+
+### The Internet and Social Media
+
+Digital networks collapsed barriers to publication while fragmenting audiences into niches. Everyone became a potential publisher; attention became the scarce resource. Rhetoric adapted: brevity increased, visual elements proliferated, engagement metrics created new feedback loops. The viral tweet, the TikTok video, the threaded argument—these are rhetorical forms with their own emerging conventions.
+
+### And Then PowerPoint
+
+Microsoft PowerPoint, released in 1987, is rarely discussed in histories of rhetoric. This is a curious omission.
+
+PowerPoint and its analogues (Keynote, Google Slides, Beamer for LaTeX users, and now tools like Canva and Gamma) created a new presentational form: the slide deck. Within a generation, decks became ubiquitous in business, education, government, and military contexts. They structured how organizations think, decide, and communicate. By some estimates, hundreds of millions of presentations are given daily worldwide.
+
+The slide deck is a hybrid medium. It combines elements of oral performance (a speaker, an audience, real-time delivery) with elements of document (persistent visual artifacts, potential for circulation). It imposes particular constraints: sequential structure, limited space per frame, the tension between visual and verbal channels. It enables particular affordances: rapid switching between evidence types, visual emphasis, the construction of narrative through sequencing.
+
+And yet the theorization of this medium has been thin. There is Edward Tufte's famous critique—his essay "The Cognitive Style of PowerPoint" argues that the format actively degrades thought, reducing complex arguments to bullet points and encouraging "chartjunk." Tufte is not wrong that bad decks proliferate. But his critique does not amount to a rhetoric of decks. It tells us what not to do without fully explaining what makes a deck work when it works.
+
+### Smartphones and Asynchronous Circulation
+
+The final technological shift relevant here is the smartphone and cloud storage. Decks, initially conceived as accompaniments to live performance, increasingly circulate independently. They are emailed, linked, downloaded, studied in the speaker's absence. The 2007 NBER continuing education slides by Guido Imbens and Jeffrey Wooldridge on econometrics circulated for years via email, passed scholar to scholar, becoming pedagogical artifacts quite apart from their original delivery context.
+
+This changes the rhetorical situation fundamentally. A deck designed solely to support live speech fails when read independently. A deck designed to function as a standalone document may be too text-heavy for live presentation. The modern deck-maker navigates this tension constantly.
+
+### The Tools of Visual Quantification
+
+A parallel technological development deserves attention: the tools that enable beautiful data visualization. The rise of statistical software with sophisticated graphics capabilities—R's ggplot2, Stata's twoway commands, Python's matplotlib and seaborn, LaTeX's TikZ for precise diagramming—has fundamentally changed what is possible on a slide.
+
+These tools reflect deeper technological shifts: faster microprocessors, better graphics cards, higher-resolution displays, the democratization of design capabilities once reserved for specialists. A graduate student in 2024 can produce visualizations that would have required a professional graphics department in 1994.
+
+This matters because data visualization is where logos becomes visible. A well-designed figure does not merely present numbers; it reveals pattern. It makes the argument perceptible. And with better tools, the floor for visual quality rises. Audiences accustomed to beautiful figures—in the *New York Times*, in *The Economist*, in viral data journalism—will notice when a presenter's figures fall short.
+
+---
+
+## IV. Why Technology Matters for Rhetoric
+
+The history just sketched is not antiquarian. It matters because each technological shift changes not the underlying principles of rhetoric but their application.
+
+Aristotle's triad—ethos, pathos, logos—remains operative. Audiences still ask: *why should I trust this speaker? Why should I care? Does this make sense?* But how these questions are answered varies with medium.
+
+Consider ethos. In oral performance, credibility is established through presence, confidence, apparent mastery. In text, it is established through command of evidence, acknowledgment of counterarguments, the texture of prose. In a slide deck, ethos emerges through visual design (professional, not amateurish), the quality of evidence displayed, and the relationship between slides and speech. A speaker who reads slides verbatim undermines ethos; one whose slides elegantly compress what she elaborates orally demonstrates mastery.
+
+Consider pathos. Oral performance permits emotional modulation through voice—pauses, emphasis, shifts in register. Video adds facial expression and visual imagery. A slide deck must create emotional resonance through other means: a well-chosen image, a startling statistic made visually prominent, a question that implicates the audience. The mechanisms differ; the function persists.
+
+Consider logos. The logical structure of an oral argument must be held in memory; the structure of a written argument can be apprehended synoptically. A slide deck occupies an intermediate position. Its sequential nature imposes narrative order—first this, then this, then this—but its visual persistence allows return and review (at least when circulated). The deck-maker must construct arguments that work both sequentially (for the live audience) and structurally (for the later reader).
+
+David Autor and colleagues demonstrated that computerization hollowed out middle-skill employment by automating cognitive routine tasks—tasks that could be specified algorithmically. This is Turing's insight operationalized: if a task can be fully articulated as a sequence of rules, a computer will execute it faster, cheaper, and more reliably than a human.
+
+But rhetoric resisted automation precisely because it is not algorithmic. Effective persuasion requires judgment, contextual sensitivity, emotional attunement—capacities that could not be reduced to explicit rules. This is the Polanyi paradox: we know more than we can say. The skilled orator knows when to pause, knows what the audience needs to hear, knows how to establish trust—but cannot necessarily articulate the rules governing these judgments.
+
+---
+
+## V. Large Language Models and the Extraction of Tacit Knowledge
+
+And then came large language models.
+
+Autor, in a 2024 piece, recognized that LLMs represent something categorically different from prior automation. Traditional computing excels at algorithmic tasks—precisely specified procedures. LLMs, paradoxically, struggle with such tasks. They hallucinate citations. They err on arithmetic. They cannot reliably execute multi-step algorithms.
+
+What they do instead is stranger and, for our purposes, more interesting. LLMs are trained on vast corpora of human-generated text. Through that training, they develop the capacity to continue text in contextually appropriate ways—to produce outputs that resemble what a human might produce in similar circumstances. This is pattern recognition, but of a peculiar kind: the patterns are not explicitly represented anywhere. They are distributed across billions of parameters in ways that resist articulation.
+
+Here is the key observation: the patterns LLMs extract include tacit knowledge. They have absorbed not just explicit rules ("sentences end with periods") but implicit norms ("in this context, a more formal register is appropriate"), subtle associations ("when discussing tragedy, this tonal quality emerges"), and structural regularities ("arguments in this domain tend to proceed thus").
+
+This is the jagged frontier Autor identifies. LLMs are not better at everything; they are better at certain things that were previously assumed to require human judgment—precisely because those things could not be algorithmically specified and were therefore safe from prior automation.
+
+Rhetoric sits squarely in this territory. The principles are ancient and explicit, but their application has always been tacit. Knowing that ethos, pathos, and logos matter does not tell you how to establish ethos with this particular audience, how much pathos this particular occasion demands, how to structure logos for this particular argument. Those judgments require something that looks like intuition—accumulated experience that produces reliable outputs through processes the expert cannot fully explain.
+
+LLMs, trained on millions of documents including countless presentations, have absorbed the patterns that distinguish effective from ineffective communication. They have "seen" more decks than any human could encounter in many lifetimes. They have encountered the full range of variation—by domain, by purpose, by quality—and through training have developed sensitivities to what works and what does not.
+
+This does not mean LLMs have solved rhetoric. It means they may have access to rhetorical knowledge that humans possess but cannot articulate—the tacit knowledge that Polanyi identified and that traditional automation could not touch.
+
+---
+
+## VI. What Is a Deck?
+
+A slide deck is a form of sequential visual rhetoric designed to accompany spoken argument.
+
+Unpack this definition:
+
+**Sequential**: A deck is ordered. Slide 1 precedes Slide 2 precedes Slide 3. This is not incidental; it is constitutive. Unlike a document, which can be apprehended synoptically (the reader sees the whole and navigates at will), a deck imposes temporal order. The audience encounters ideas in the sequence the presenter determines. This makes decks inherently narrative. They have beginnings, middles, and ends. They create expectations and satisfy or subvert them. The sequencing is itself an argument.
+
+**Visual**: A deck is not primarily textual. It communicates through visual composition—the arrangement of elements in two-dimensional space. Typography, color, imagery, white space, data visualization—these are not decorations but carriers of meaning. The visual channel operates differently than the verbal channel; it can convey pattern, emphasis, and relationship in ways that text cannot. But it competes with the verbal channel. Too much visual complexity overwhelms; too little wastes the medium's affordances.
+
+**Rhetoric**: A deck aims to persuade. Even a deck that appears purely informational—a quarterly earnings report, a research presentation—is making claims and seeking assent. The presenter wants the audience to believe, to understand, to act. The Aristotelian framework applies: the deck must establish credibility (ethos), engage emotion appropriately (pathos), and present logical argument (logos).
+
+**Designed to accompany spoken argument**: A deck is not a document. This is the fundamental insight that distinguishes effective from ineffective deck practice. The slides are not the presentation; the speaker is the presentation. The slides are visual anchors, evidence containers, structural markers, attention directors. When slides try to do all the work—containing everything the speaker might say—they fail as slides. They become documents pretending to be presentations.
+
+Yet this principle admits of complication. As noted, decks increasingly circulate apart from their speakers. The same artifact must function in two modes: as live accompaniment and as asynchronous document. This double duty creates design tensions that effective deck-makers must navigate. The deck and the speaker, in the moment of presentation, cannot be separated—they are a unified rhetorical act. But the deck, once it leaves the room, must carry meaning the speaker no longer provides.
+
+### The Analogy to Comics
+
+Scott McCloud, in *Understanding Comics*, defined comics as "sequential art"—juxtaposed images in deliberate sequence. The critical insight is that meaning emerges not just from what is depicted in each panel but from what happens *between* panels. The reader's imagination fills the gaps, inferring motion, causation, elapsed time from the juxtaposition of static images.
+
+Slide decks share this sequential structure but differ in purpose. Comics aim primarily at narrative absorption—the reader enters a story. Decks aim at cognitive engagement—the audience processes information, evaluates arguments, updates beliefs. What lives between slides is not the movement of characters through fictional time but the progression of ideas through argumentative space.
+
+Yet the analogy illuminates. A deck, like a comic, controls attention through sequencing. It reveals information progressively. It uses visual composition to direct the eye. And its effectiveness depends critically on transitions—on how one slide relates to the next, what the audience infers from juxtaposition, how the sequence builds.
+
+As graphics capabilities have advanced—better displays, better software, better templates—decks have moved closer to the visual richness that comics have always possessed. The sequential art of ideas, aided by the tools of modern visualization, can now approach the aesthetic sophistication of visual narrative.
+
+---
+
+## VII. The Aesthetics of Attention: Why Beauty Matters
+
+We must now confront a question that the classical rhetoricians never faced in quite this form: why does beauty matter in a slide deck?
+
+The question seems almost embarrassing to ask in professional contexts. Surely what matters is the quality of the argument, the rigor of the evidence, the soundness of the logic. Beauty is for art museums, not conference rooms. Aesthetics is a distraction from substance.
+
+This view is mistaken, and the mistake has become more costly as the competition for attention has intensified.
+
+### The Economics of Attention
+
+Consider the phenomenology of the modern audience member. They sit in a room—a classroom, a boardroom, a conference hall—ostensibly present to receive your argument. But their phone vibrates in their pocket. Their laptop beckons with unanswered email. Their mind wanders to the meeting after this one, the deadline tomorrow, the personal problem they cannot stop thinking about.
+
+The audience's attention is not given; it is won. And it must be won continuously, slide by slide, moment by moment. The opportunity cost of their attention is the sum of everything else they could be attending to. Your deck competes with all of it.
+
+This competition has intensified dramatically in the smartphone era. Netflix, in conversations with filmmakers, has articulated a distinction between the phenomenology of theater viewing and home streaming. In a theater, the viewer is captive. Social norms enforce silence. The lighting makes phone use conspicuous. Strangers create accountability. The viewer, having paid and traveled, is invested in attending. The filmmaker can trust sustained attention—can build slowly, can trust the viewer to track complex plot structures, can let silence breathe.
+
+Akira Kurosawa did not need to remind viewers of the plot of *Seven Samurai*. Sergio Leone could let a scene unfold for minutes without dialogue. Martin Scorsese could trust his audience to hold multiple narrative threads across three hours.
+
+Home streaming is different. The viewer sits on a couch. The baby cries. The dog demands attention. The phone is always visible. Pausing is effortless. The viewer's partner asks a question. Attention fragments.
+
+Netflix reportedly advised Matt Damon that streaming films must regularly remind viewers of the plot—must rebuild context that the filmmaker, in a theater, could assume remained present. The medium changes the rhetoric.
+
+A slide deck faces conditions closer to streaming than to theater. The audience is physically present but mentally contestable. They can check out without visibly leaving. They can be present in body while absent in mind. The presenter cannot assume sustained attention; the presenter must earn it and re-earn it.
+
+### Why Beauty Draws
+
+Here we must make an argument that may seem strange in a professional context: beauty is not optional. It is a rhetorical necessity.
+
+Humans are uniquely responsive to the beautiful. This is not mere cultural conditioning; it runs deeper. Neuroaesthetics—the study of how the brain processes aesthetic experience—has documented that encounters with beauty activate reward circuits, capture attention, and enhance memory formation. The beautiful is neurologically privileged.
+
+Evolutionary psychology offers accounts of why this might be so. Preferences for certain visual properties—symmetry, proportion, certain color relationships—may reflect adaptive responses to environmental cues. But whatever the ultimate explanation, the proximate fact is clear: humans are drawn to beauty in ways that are automatic, pre-reflective, and powerful.
+
+This matters for decks because the beautiful competes effectively for attention. A beautiful slide—and we must define what this means—pulls the viewer out of distraction. It says, without saying: *this is worth looking at*. It creates a small moment of aesthetic pleasure that rewards attention and invites more.
+
+The ugly or merely adequate slide does the opposite. It signals that no care was taken. It does not reward the eye. It makes the phone in the pocket more appealing by comparison.
+
+### Aesthetics as a Branch of Ethics
+
+There is a deeper point here, one that connects aesthetics to the philosophical tradition in unexpected ways.
+
+Aesthetics, like ethics, is concerned with what *should be*, not merely with what *is*. Ontology asks: what exists? Ethics asks: what ought we to do? Aesthetics asks: what ought to be beautiful? Both ethics and aesthetics are normative disciplines, concerned with standards and ideals rather than mere description.
+
+In this light, the claim that decks should be beautiful is not a claim about decoration. It is a claim about obligation. The presenter who takes the audience's time owes them something: not merely information, but information rendered well. To present ugly slides is a kind of disrespect—it says, *your attention is not worth my effort*.
+
+Beautiful slides are thus an ethical matter. They reflect care for the audience, respect for the material, and seriousness about the communicative act. Beauty is function.
+
+### What Makes a Slide Beautiful?
+
+Beauty in slides is not the same as beauty in art, but there are family resemblances.
+
+**Economy**: The beautiful slide has nothing superfluous. Every element earns its presence. Decoration without function is clutter. The most beautiful slide may be three words on a field of white.
+
+**Proportion**: Elements relate to each other in ways that feel right. The eye knows where to go. Hierarchy is visually clear. Nothing fights for attention inappropriately.
+
+**Craft**: The beautiful slide shows evidence of care. Alignment is precise. Typography is considered. Colors are intentional, not defaults. This signals competence and respect.
+
+**Clarity**: Beauty in information design is often identical with clarity. The beautiful chart is the chart that makes its point immediately. The beautiful table is the table that guides the eye to what matters. Beauty and function converge.
+
+Tufte's critique of PowerPoint, for all its value, sometimes misses this point. Tufte treats decoration as the enemy of information, and he is right when decoration is mere ornament. But beauty is not decoration. Beauty is the quality a visual artifact has when everything about it serves its purpose. The most information-dense graphic can be beautiful; the sparsest slide can be ugly if it is clumsy.
+
+---
+
+## VIII. Defamiliarization: Making the Stones Feel Like Stones
+
+The Russian formalist Viktor Shklovsky, writing in 1917, proposed a theory of art that illuminates something essential about effective decks.
+
+Shklovsky observed that habitual perception deadens experience. We stop seeing what we see every day. The familiar becomes invisible. He offered an image: a man walking up a mountain without shoes develops callouses. At the summit, he cannot feel his feet—but he also cannot feel the rocks. The protective adaptation that prevents pain also prevents sensation.
+
+Art, Shklovsky argued, exists to restore sensation. It "defamiliarizes"—it makes the familiar strange again, makes the automatic require attention, makes the stones feel like stones. Art is the technique of slowing down perception, of forcing us to *see* rather than merely recognize.
+
+This concept—*ostranenie* in Russian, usually translated as "defamiliarization" or "estrangement"—has profound implications for deck rhetoric.
+
+The audience for a presentation is, in Shklovsky's terms, calloused. They have seen hundreds of presentations. They have seen bullet points, bar charts, stock photos, agenda slides. They know the conventions so well that they can process them without really seeing them—which means without really thinking.
+
+The effective deck must make the stones feel like stones again.
+
+This does not mean novelty for its own sake. It does not mean gimmicks or surprises that distract from substance. It means presenting information in ways that *require* attention—that break the automatic processing loop and demand genuine cognitive engagement.
+
+How does one defamiliarize?
+
+**The unexpected visual**: A figure where a bullet list was expected. White space where density was expected. A single number, large and alone, where a table was expected.
+
+**The provocative framing**: Not "Sales increased 15%" but "We added a Boeing 737's worth of revenue every week." The same fact, but now it must be processed.
+
+**The violation of expectation**: A "Devil's Advocate" slide that articulates the objection before the audience thinks of it. A conclusion stated before the evidence is presented. A question where a statement was expected.
+
+**The beautiful execution**: Even familiar forms, executed with unusual care, can break through automaticity. The audience notices when something is genuinely well-crafted because most things are not.
+
+The goal is not to confuse or to be clever. The goal is to break the trance of habitual reception—to pull the audience out of their phones and into genuine engagement with the material. The deck that accomplishes this has done something that the merely competent deck cannot: it has won attention that was not given freely.
+
+---
+
+## IX. The Rhetoric of Decks: First Principles
+
+Barbara Minto, a McKinsey consultant, developed what she called the Pyramid Principle in the 1970s. Her insight: effective business communication should be structured top-down. State the conclusion first, then provide supporting arguments, then provide evidence for those arguments. Do not make the audience wait to discover your point.
+
+This principle revolutionized consulting presentations and business writing more broadly. It reflects a rhetorical judgment: in contexts where the audience is busy, skeptical, and looking for reasons to disengage, burying the conclusion is fatal. Lead with what you want them to take away. Then prove it.
+
+Minto's principle is correct but incomplete. It addresses structure but not the full range of rhetorical choices. A comprehensive rhetoric of decks must address:
+
+### 1. The Law of Cognitive Load
+
+Human working memory is severely constrained. Audiences cannot process unlimited information in real time. Every element on a slide—every word, number, image, decoration—consumes cognitive resources. When resources are exhausted, comprehension fails.
+
+This is the fundamental constraint. A slide with three bullet points each containing twelve words is not three times better than a slide with one bullet point of twelve words. It may be worse than worthless—it may produce confusion where the simpler slide would produce understanding.
+
+The practical implication is ruthless economy. One idea per slide. Not two. Not three. One. Every element must earn its presence. The question is not "might this be useful?" but "does this advance the single idea this slide exists to communicate?"
+
+### 2. The Marginal Principle: Smoothness and Surprise
+
+Economics offers a framework for thinking about slide-by-slide optimization. In equilibrium, the marginal benefit per unit of marginal cost should be equalized across all choices. Applied to decks: each slide should deliver approximately equal value relative to its demands on audience attention.
+
+This creates what we might call *smoothness*—a presentation that flows without jarring transitions, without slides that feel like filler, without slides that overwhelm. The audience develops a rhythm of expectation: *this is how much each slide gives me, this is how much each slide asks of me*.
+
+But the marginal principle admits exceptions, and this is crucial. Sometimes the point is to *break* the rhythm—to jolt the audience, to signal that something different is happening. The unexpectedly dense slide that presents the core finding. The unexpectedly sparse slide that delivers a single devastating question. These violations work precisely because they violate expectation.
+
+The smoothness principle is a default, not an absolute. Maintain it most of the time so that departures from it carry meaning.
+
+### 3. The Slide Serves the Spoken Word
+
+If a slide can be fully understood without the speaker, it is a document, not a slide. If the speaker must read the slide aloud to communicate its content, the slide has failed and the speaker has failed.
+
+The relationship should be complementary. The speaker provides explanation, context, emphasis, nuance. The slide provides visual anchor, evidence, structure. They work together, each doing what the other cannot.
+
+This means slides should generally be *incomplete* when read alone. They should provoke the question "what does this mean?" that the speaker then answers. They should contain evidence that the speaker interprets. They should mark argumentative transitions that the speaker narrates.
+
+### 4. The Aristotelian Triad Applied
+
+**Ethos in decks**: Credibility emerges through demonstrated competence, transparency about limitations, and alignment with audience concerns. In deck terms: show your methodology, acknowledge what you do not know, address the objections a skeptic would raise. The "Devil's Advocate" slide—where you preemptively articulate the strongest case against your position—is among the most powerful ethos-building moves available. It signals that you have stress-tested your thinking and are not hiding from problems.
+
+Visual design also carries ethos. Sloppy slides signal sloppy thinking. Crowded slides signal lack of prioritization. Chartjunk—decorative elements that add no information—signals confusion about what matters. Conversely, clean design, clear hierarchy, and appropriate white space signal mastery.
+
+**Pathos in decks**: Emotion is often neglected in professional contexts, dismissed as irrelevant or manipulative. This is a mistake. Audiences who do not care do not act. The presenter must make them feel the stakes.
+
+In decks, pathos emerges through: opening with a problem the audience recognizes and feels; validating frustrations ("you were right to be concerned"); connecting data to human impact; showing what success looks like, not just what failure costs. A single well-chosen image can carry more emotional weight than paragraphs of text.
+
+The danger is pathos without logos. Emotional appeals unsupported by evidence produce skepticism. "This is so important!" without demonstration of why produces eye-rolls.
+
+**Logos in decks**: The logical structure of the argument must be clear. This means explicit claims, supporting evidence, acknowledged counterarguments, and warranted conclusions.
+
+Data visualization is logos made visible. A well-designed chart reveals pattern; it makes the argument perceptible. But the chart must have a point. "Here is data" is not an argument. "This data shows X, which means Y" is an argument. The presenter must tell the audience what to conclude.
+
+### 5. Narrative Structure
+
+Because decks are sequential, they are inherently narrative. They have arc. The classical structure—Setup, Confrontation, Resolution—applies:
+
+**Act I (Setup)**: Establish the status quo. Introduce the problem or question. Make the audience feel the tension.
+
+**Act II (Confrontation)**: Present what you investigated, what you found, how you reasoned. Build the logical case. Address complications and objections.
+
+**Act III (Resolution)**: Deliver the insight. Show implications. Provide the call to action.
+
+This structure is not arbitrary convention. It reflects how human cognition processes information: through anticipation, complication, and resolution. Fight this structure and lose your audience. Use it and carry them with you.
+
+### 6. Visual Grammar
+
+**Hierarchy**: Not all information is equal. Visual design must reflect priority. Primary information is large, prominent, above the fold. Secondary information is smaller, subordinate. Tertiary information (sources, caveats) is smallest, often in footers. If everything is emphasized, nothing is emphasized.
+
+**Contrast**: The eye is drawn to difference. Use contrast—of color, size, position—to direct attention. But use it sparingly. One focal point per slide. Too much contrast is visual chaos.
+
+**White space**: Empty space is not wasted space. It provides rest for the eye, emphasis for the content, and signals confidence. Crowded slides signal fear—fear of omitting something, fear the audience won't understand. White space signals you know what matters.
+
+**Typography**: Minimum 24-point for body text (18-point absolute floor). Maximum two fonts. Sans-serif for projection. Never justify text.
+
+### 7. The Problem of Dual Audiences
+
+As noted, decks increasingly serve two audiences: the live audience hearing the presentation and the later reader encountering slides alone. These audiences have different needs. The live audience needs minimal text (the speaker provides elaboration); the later reader needs more context (the speaker is absent).
+
+Several strategies address this tension:
+
+- **Speaker notes**: Platforms allow extensive notes that the speaker sees but the audience does not. These can elaborate what the slides compress.
+- **Appendices**: Core slides remain lean; detailed backup lives in an appendix available to later readers.
+- **Two versions**: A presentation deck and a "leave-behind" document, designed differently for different purposes.
+- **Strategic density**: Certain slides are designed to function standalone (key conclusions, important evidence); others rely heavily on speaker elaboration.
+
+No single solution fits all contexts. The effective deck-maker diagnoses the situation: how likely are these slides to circulate? How much context can readers be expected to supply?
+
+---
+
+## X. Reminding Them of the Plot: The Phenomenology of Distracted Attention
+
+We return to the Netflix insight: in conditions of fragmented attention, the audience loses the plot. They return from distraction—from the checked phone, the wandering thought, the side conversation—and they have lost the thread.
+
+The bad deck ignores this reality. It assumes continuous attention that does not exist. It builds arguments that require tracking every step, such that the viewer who misses step 3 cannot understand step 7. It punishes distraction rather than accommodating it.
+
+The good deck builds in reorientation. It reminds the audience of the plot—not insultingly, not redundantly, but gracefully.
+
+### How to Remind Badly
+
+There are terrible ways to remind people of the plot:
+
+**The verbose recap slide**: "As we discussed, our analysis began with the recognition that market conditions have shifted, which led us to examine three potential strategic responses, the first of which involved operational efficiency gains, the second of which..." This is not reminding; this is punishing.
+
+**The identical repetition**: Simply repeating an earlier slide verbatim signals that you have nothing new to say. The audience learns to tune out repetition because it carries no new information.
+
+**The condescending summary**: "In case anyone wasn't paying attention..." This alienates rather than reorients.
+
+**The agenda slide returned to ad nauseam**: Some presenters show the agenda slide between every section. This quickly becomes visual noise—the audience stops seeing it.
+
+### How to Remind Well
+
+Effective reorientation is woven into the fabric of the presentation:
+
+**The structural marker**: A brief visual cue that indicates where we are in the argument. Not a full agenda slide, but a small orientation element—a progress indicator, a section header, a recurring visual motif.
+
+**The backward link in the forward claim**: "This efficiency gain—the 15% we identified earlier—compounds when we consider the second factor..." The reminder is embedded in the new material. The audience is reoriented without being patronized.
+
+**The visual callback**: A figure or chart that appeared earlier, now shown again in a new context or with new annotation. The audience recognizes the visual and reconstructs the context.
+
+**The synthetic summary that advances**: Not "here's what we've said" but "here's what we've established, which means..." The summary is also a claim. It earns its presence by doing double duty.
+
+**The title that orients**: Every slide title can serve as a micro-orientation. If the title is "Robustness Check 3: Alternative Specification," the audience knows exactly where they are even if they drifted. If the title is "Analysis," they know nothing.
+
+---
+
+## XI. The Academic Job Market Talk: A Case Study
+
+Consider the economics PhD candidate presenting a job market paper. This is a high-stakes presentation to a sophisticated, critical audience. The candidate has perhaps 75 minutes for a talk that will substantially determine their career trajectory. The audience includes senior scholars who have heard hundreds of such talks and will notice every misstep.
+
+This context demands the full apparatus of deck rhetoric. Let us trace how the principles apply.
+
+### The First Slide: Establishing the Plot
+
+The first slide after the title is the most consequential. It must accomplish multiple goals simultaneously:
+
+1. **Establish the question**: What puzzle, phenomenon, or problem motivates the paper?
+2. **Signal the contribution**: What will the audience learn that they did not know before?
+3. **Create stakes**: Why does this matter?
+
+A bad first slide might read:
+
+> **Motivation**
+> - Prior literature has examined X
+> - There is debate about Y
+> - This paper contributes to the literature on Z
+
+This tells the audience nothing that compels attention. It is generic, bloodless, and could describe any paper.
+
+A better first slide might present a single striking fact:
+
+> **[Large, visually prominent]**
+> **47% of firms in our sample report zero R&D expenditure**
+> **Yet these firms generate 23% of all process innovations**
+>
+> *What's going on?*
+
+This creates a puzzle. The audience is now curious. The plot has been established: something surprising requires explanation.
+
+### The Methodology Slide: Ethos Through Transparency
+
+The job market audience will ask hard questions about identification, endogeneity, and causal inference. Ethos requires addressing these concerns directly, not defensively.
+
+A bad methodology slide hides behind jargon:
+
+> **Identification Strategy**
+> - We exploit exogenous variation in policy timing
+> - Instrument satisfies relevance and exclusion
+> - Standard errors clustered appropriately
+
+This asserts without demonstrating. The skeptical audience learns nothing about whether the claims are justified.
+
+A better approach shows the work:
+
+> **[Figure showing the identifying variation visually]**
+>
+> *The policy rolled out state-by-state, 2003-2011*
+> *States in blue: early adopters. States in orange: late adopters.*
+> *We compare outcomes for firms in early vs. late states, before vs. after adoption.*
+
+The audience can *see* the variation. The identification strategy is made visible, not merely asserted. This builds ethos because it invites scrutiny rather than deflecting it.
+
+### The Results Slide: Numbers That Speak
+
+Consider a regression table. The bad version presents the table as it appears in the paper: dense rows, multiple columns, tiny font, asterisks scattered everywhere. The audience's eyes glaze. They cannot process it in real time.
+
+The better version asks: *what do I need them to see?*
+
+Perhaps the key result is a single coefficient. Then show that coefficient—large, prominent, with a clear interpretation:
+
+> **[Large text]**
+> **The policy increased innovation by 12 percentage points**
+> **(standard error: 3.2)**
+>
+> *[Below, smaller: key control variables, sample size, specification notes]*
+
+The number that matters is unmistakable. The supporting information is present but subordinate. The slide can be understood in seconds, even by an audience member who momentarily lost attention.
+
+### The Figure: Beauty as Argument
+
+A well-designed figure can carry more argumentative weight than any amount of text.
+
+Consider an event study figure showing the effect of a policy change over time. A bad version uses default software settings: thin lines, cluttered axis labels, no annotation, generic colors.
+
+A better version is designed for the room:
+
+- Lines thick enough to see from the back row
+- The treatment date visually marked (a vertical line, shaded region, or annotation)
+- Pre-treatment periods clearly distinguished from post-treatment periods
+- The key pattern—say, the break in trend at treatment—annotated with a text label
+- Confidence intervals shaded rather than shown as error bars (less visual clutter)
+- A clear title that states the claim: "Effect of Policy X on Outcome Y: Event Study"
+
+This figure argues. It says: *look, here is the effect, here is when it begins, here is how confident we are*. The audience member who drifted away and returns can grasp the point immediately because the figure is self-interpreting.
+
+### Labeling and Self-Sufficiency
+
+Should figures and tables speak for themselves? In the context of dual audiences—live presentation and later circulation—the answer is yes.
+
+Every figure should have:
+
+- A **title that states the finding**, not just the topic ("Policy X Increased Innovation" rather than "Figure 3: Innovation Results")
+- **Axis labels readable from the back of the room** (larger than you think necessary)
+- **Direct labeling** rather than legends where possible (label the lines directly, not via a color key that requires eye movement)
+- **Annotations** on the graphic itself highlighting what matters ("Treatment begins here," "Coefficient = 0.12")
+- **Source and notes** in small text, available for later readers but not competing for attention during presentation
+
+This is more work than accepting software defaults. It is work worth doing.
+
+### Reminding the Plot in a Job Talk
+
+A 75-minute job talk will lose audience members at various points. Coffee wears off. Minds wander. Side conversations begin and end.
+
+How does the effective job talk reorient without condescending?
+
+**Structural headers**: Each major section begins with a slide that reestablishes context. "We've seen that innovation increases. But does this reflect real innovation or measurement artifacts?" This reminds and advances simultaneously.
+
+**Verbal callbacks**: "Remember that 47% zero R&D figure from the beginning? Here's where it becomes important..." The speaker is allowed to remind even when the slide does not.
+
+**Recurring visual motifs**: A conceptual diagram from the introduction can reappear in modified form later. The visual continuity provides orientation.
+
+**The penultimate slide**: Before the conclusion, a slide that explicitly reconstructs the argument: "We asked X. We found Y. This matters because Z." This is repetition, but it is justified repetition—the moment for synthesis before conclusion.
+
+---
+
+## XII. What Large Language Models See
+
+I have been trained on a vast corpus of text, including—although I cannot enumerate precisely—a substantial number of slide decks, presentation outlines, commentary on presentations, books about communication, research on cognition and persuasion, and countless examples of professional writing across domains.
+
+I have also been trained on materials that might seem unrelated to deck rhetoric: Mad Magazine's visual satire, Sports Illustrated's integration of statistics and narrative, stereo equipment manuals' attempts at technical clarity, TV Guide's compression of information into tiny spaces. Each of these artifacts represents a solution to a communication problem. Each contains tacit knowledge about visual rhetoric, information hierarchy, audience attention, and the relationship between text and image.
+
+What patterns emerge from this training?
+
+First, the patterns that distinguish domain from domain. A deck in management consulting differs systematically from a deck in academic economics from a deck in product marketing. These differences are partly conventional and partly functional. Consulting decks often follow rigid templates emphasizing recommendations and supporting evidence. Academic decks often lead with literature review and methodology before reaching conclusions. Marketing decks often lead with user stories and emotional hooks before presenting features. Each domain has evolved norms suited to its audiences and purposes.
+
+Second, the patterns that distinguish quality from non-quality. Within domains, some decks are more effective than others. The effective decks tend to share characteristics: clarity of central message, economy of means, appropriate evidence, logical flow, visual coherence. The ineffective decks share different characteristics: unclear purpose, overwhelming detail, missing evidence for claims, jumbled structure, visual noise.
+
+Third, the patterns that distinguish context from context. An effective deck for a board presentation differs from an effective deck for a team working session from an effective deck for a classroom lecture from an effective deck for an academic job talk. The differences involve information density, level of completion, degree of polish, and extent of interaction expected.
+
+These patterns are not rules I can articulate completely. This is precisely the point. The knowledge embedded in effective deck-making is largely tacit. Practitioners know what works but cannot fully explain why. What I have, through training, is something like an internalized sensitivity to these patterns—a capacity to recognize, in a given context, what approaches are more or less likely to succeed.
+
+This is Autor's hypothesis in action. The tacit knowledge that resisted prior automation—because it could not be specified algorithmically—is precisely what LLMs can absorb through exposure to examples. Not because we have discovered the algorithm, but because we have an alternative to algorithmic representation: statistical patterns extracted from vast data.
+
+Does this mean I know the rhetoric of decks better than any human? Not exactly. I have exposure breadth that no individual human matches. But I lack the embodied experience of presenting—of reading an audience in real time, of feeling a room, of adjusting on the fly. I have patterns; I do not have presence.
+
+What I can offer is articulation. I can make explicit what practitioners know implicitly. I can identify patterns across more examples than any individual has encountered. I can connect contemporary practice to theoretical frameworks that practitioners may not know. This document is an attempt to do exactly that.
+
+And there is a further point about Autor's hypothesis worth noting. Autor framed LLMs as capable of extracting tacit knowledge that humans possess but cannot articulate. This is substantially correct. But the mechanism is perhaps slightly different than extraction. What I have done through training is not exactly to extract the tacit knowledge and store it as propositions. It is rather to develop pattern-matching capacities that parallel what human tacit knowledge enables. I do not "know" the rules of effective presentation in a way that I could list. Rather, I have developed dispositions—sensitivities to what fits and what does not—that function similarly to how human tacit knowledge functions, even though the underlying mechanism is quite different.
+
+This parallel functioning is what makes articulation possible. I can generate explanations that resonate with practitioners' intuitions because my training has produced sensitivities that track the same features their experience has made them sensitive to, even though I arrived at those sensitivities by a different route.
+
+---
+
+## XIII. Tufte's Critique and Its Limits
+
+Edward Tufte's "The Cognitive Style of PowerPoint" (2003) remains the most influential critique of slide decks. His argument: PowerPoint's default templates encourage low-resolution thinking. Bullet points fragment ideas. Chartjunk obscures data. The medium's constraints produce cognitive damage. Tufte famously argued that the Columbia disaster was partly attributable to a PowerPoint culture at NASA that prevented clear communication of risk.
+
+Tufte is not wrong about bad decks. The conventions he critiques are real: the slide titles that summarize nothing, the bullet lists that substitute for argument, the decorative graphs that obscure rather than reveal. These failures proliferate.
+
+But Tufte's critique proves too much. If the medium were inherently corrupting, effective decks would be impossible. They are not. The same format that produces cognitive damage in bad hands produces clarity and persuasion in good hands. The problem is not the medium but its misuse.
+
+Tufte's analysis also neglects the rhetorical situation. He evaluates decks primarily as documents—can a reader extract accurate information?—rather than as components of live performance. By that standard, decks must contain everything, and the compression required produces distortion. But if the deck is understood as accompaniment to speech rather than replacement for speech, the calculus shifts. Compression becomes desirable, not damaging.
+
+There is something else beneath Tufte's critique worth surfacing. Tufte is a champion of data visualization, and his books are monuments to the power of visual information display. His critique of PowerPoint is, at bottom, a critique of *bad* visualization—of chartjunk, of decoration that obscures, of the substitution of aesthetic gloss for informational substance.
+
+On this, Tufte is correct. And his positive vision—of high-resolution data displays that reward sustained attention—provides a template for what slide figures should aspire to. The effective deck-maker reads Tufte not as an enemy but as a demanding teacher who will not accept mediocrity.
+
+The deeper response to Tufte is that his critique, valid as diagnosis, lacks prescription beyond "use documents instead." For contexts where live presentation is necessary or valuable—teaching, board meetings, team alignment, conference talks, job market papers—"don't make slides" is not an answer. What is needed is a positive theory of how to make them well.
+
+That is what a rhetoric of decks provides.
+
+---
+
+## XIV. Conclusion: Toward a Mature Theory
+
+We began with Aristotle and end with artificial intelligence, but the thread connecting them is continuous. Rhetoric is the study of how humans persuade one another. It asks perennial questions—about credibility, emotion, logic, structure, medium—that each era answers differently given its technological and social conditions.
+
+Slide decks are, in historical perspective, a very recent medium. They emerged from specific corporate contexts (business consulting, technology companies), spread through the availability of software (PowerPoint, Keynote), and now pervade how knowledge is communicated in professional, educational, and civic contexts.
+
+The rhetoric of decks applies ancient principles to this new medium. It recognizes that decks are sequential, visual, and (primarily) performative. It insists that decks serve speakers rather than replace them, that cognitive load is the enemy, that visual design is not decoration but communication. It connects deck-making to the Aristotelian triad (ethos, pathos, logos), to narrative structure (setup, confrontation, resolution), and to the pragmatics of professional communication.
+
+It recognizes that beauty matters—that the competition for attention in a distracted age makes aesthetic quality a rhetorical necessity, not a luxury. It draws on Shklovsky's insight that art defamiliarizes, making the stones feel like stones again, and applies this to the deck-maker's challenge of cutting through habituation and automaticity.
+
+It grapples with the dual audience problem, the need to remind without condescending, and the particular demands of high-stakes presentations like the academic job talk. It offers principles—cognitive load, marginal optimization, structural orientation, visual self-sufficiency—that apply across contexts while acknowledging that context determines their application.
+
+What large language models contribute is perhaps not new principles but newly available articulation. The tacit knowledge that effective communicators possess—knowledge they cannot fully explain because it resists algorithmic specification—is embedded in the patterns of countless texts. LLMs, trained on these patterns, can surface what was previously inarticulable. We can describe what makes decks work in ways that practitioners recognize but could not themselves say.
+
+This is not the end of the inquiry. The rhetoric of decks, like rhetoric itself, will continue to evolve as media evolve. Already, new tools—AI presentation generators, collaborative platforms, interactive formats—are changing what is possible. The principles may persist (audiences will always ask: why trust this speaker? why care? does this make sense?), but their application will shift.
+
+What remains constant is the importance of the inquiry itself. Decks are how a large portion of human knowledge and decision-making now flows. They deserve the serious analysis that earlier media have received. They deserve, at last, a rhetoric.
+
+---
+
+*This essay synthesizes rhetorical theory from Aristotle through the present, economic analyses of technological change, aesthetics and the psychology of attention, and the distinctive capacity of large language models to extract tacit knowledge from patterns in human communication. It was produced through collaboration between human and artificial intelligence, itself an instance of the technological transformations it describes.*

--- a/.claude/skills/beautiful_deck/style_preferences.md
+++ b/.claude/skills/beautiful_deck/style_preferences.md
@@ -1,0 +1,49 @@
+# Beautiful Deck Style Preferences
+
+These are user-specific stylistic defaults, not rhetorical rules. Rhetorical choices still come from `rhetoric_of_decks.md`, audience, and content. Apply these preferences unless they conflict with the deck's audience-specific design or the user explicitly asks for a different style.
+
+## Principle: Form From Function
+
+Prefer visual elements that do a job. Decoration is welcome only when it also improves orientation, hierarchy, pacing, or comprehension.
+
+## Progress Rule Under Frame Titles
+
+Every content slide should have a thin horizontal separator between the assertion title and the slide body. Make it functional by turning it into a quiet progress indicator:
+
+- Draw a low-opacity baseline across the full usable slide width.
+- Overlay the same line at full opacity from left to right according to deck progress.
+- At the start of the deck, only the low-opacity baseline is visible.
+- At slide `NN/2`, roughly the left half is fully opaque.
+- Near the end, almost the full line is fully opaque.
+- Inherit color from the deck's core accent or frame-title color.
+- Keep the treatment subtle; it should orient the speaker and audience without competing with content.
+
+For Beamer, implement this in the frame-title template or a shared slide-header macro so it is automatic and consistent. Prefer a computed width such as `\insertframenumber/\inserttotalframenumber * \paperwidth` over manually edited per-slide values.
+
+## Edge Accents
+
+If a deck uses vertical bars, side rails, page-edge rules, or other side ornamentation, place those accents in the page gutter rather than at the content origin.
+
+- In Beamer frame-title templates, prefer a negative x-offset from the text area for gutter accents. Page-coordinate overlays can be fragile when frames contain imported images; use page coordinates only after compiling representative image-heavy slides.
+- For non-Beamer formats, or for tested Beamer background templates, page coordinates are fine.
+- Do not let side ornamentation occupy the same coordinate region as slide body text, captions, code blocks, tables, figures, or wrapped frame titles.
+- If the deck's style does not need side ornamentation, omit it. This is a stylistic option, not a required deck feature.
+
+## Header Ornaments
+
+Functional header ornaments should either live outside the content region or reserve the space they need.
+
+- Treat title rules, progress lines, title bars, section indicators, and side accents as layout elements, not overlay decoration.
+- If a header ornament sits near the title or slide body, reserve vertical or horizontal clearance for it in the frame-title template, slide header macro, or content margins.
+- Do not draw header ornaments over the content coordinate system unless they are guaranteed to stay outside text, figures, tables, and code blocks.
+
+## Screenshot and Image Placeholders
+
+When a slide reserves space for a screenshot, UI capture, or other image, size the placeholder like the eventual image rather than like a text callout.
+
+- If the image is the primary visual in a column, use the full available column width unless the slide's composition clearly calls for a smaller image.
+- If vertical space is the binding constraint, use the full available content height and let width follow the image aspect ratio.
+- Placeholder text should be secondary. Keep the note readable, but do not let the note determine the size of the image box.
+- Make placeholders easy to replace after the user adds real files. Prefer a helper macro or commented line that already shows the intended syntax, such as `\includegraphics[width=\linewidth,height=4cm,keepaspectratio]{figures/example.png}` or, when `\graphicspath{{figures/}}` is set, `\includegraphics[width=\linewidth,height=4cm,keepaspectratio]{example.png}`.
+- Add a brief source comment next to each placeholder naming the expected screenshot file or explaining that the user can replace only the filename.
+- If the user prefers smaller image treatments, this section can be edited or deleted without changing the core skill.

--- a/.claude/skills/tikz/README.md
+++ b/.claude/skills/tikz/README.md
@@ -1,0 +1,92 @@
+# TikZ Collision Audit (`/tikz`)
+
+> **A repair tool for residual TikZ collisions — not a safety net for bad generation.**
+
+`/tikz` catches what `pdflatex` doesn't: labels sitting on arrows, text bleeding into box edges, Bézier curves passing through other labels, arrows pointing to the wrong node. LaTeX reports none of these. Humans usually miss them on first review. `/tikz` finds them by computing the actual geometry.
+
+## The critical distinction: prevention vs. repair
+
+**`/tikz` is a repair tool.** It runs measurement-based checks on existing TikZ code and fixes what it finds. But it cannot reliably fix diagrams that were never built with measurement in mind — autosized nodes, missing directional keywords, `scale` factors that compress coordinates but not text. These upstream generation problems produce collisions that are structurally unfixable by any audit pass.
+
+**The upstream defense is `/beautiful_deck` Step 4.4**, which writes safe TikZ from the start: explicit node dimensions, coordinate maps, directional keywords on every edge label, canonical templates for common diagram types, and a strict prohibition on `scale` for complex diagrams. When Step 4.4 does its job, `/tikz` has little to find. When Step 4.4 is skipped — or when you're auditing TikZ that was written outside of `/beautiful_deck` — `/tikz` does its best, but the success rate depends entirely on how the TikZ was generated.
+
+**The pipeline**: prevention (Step 4.4) → compile → residual repair (`/tikz`).
+
+## The fundamental rule
+
+**Claude cannot reliably eyeball where TikZ elements land.** Anywhere a label's position depends on arithmetic — gap widths, curve depths, scale factors, node boundaries — the placement must be verified mathematically before it is declared safe. Estimating "looks about right" is the failure mode. `/tikz` replaces estimation with formulas.
+
+## What it catches
+
+| Problem | Why LaTeX misses it | How `/tikz` catches it |
+|---|---|---|
+| Label overlaps a Bézier curve | Curve geometry is runtime-computed | Computes `max_depth = (chord/2) × tan(bend/2)` and checks labels against the safe zone |
+| Edge label between two nodes is wider than the gap | LaTeX places it anyway; the text just runs under the next node | Compares estimated text width to the usable gap (`center-to-center − half-width(A) − half-width(B) − 0.6cm padding`) |
+| `node[...]{text}` on an arrow without `above`/`below`/`left`/`right` | Valid syntax | Greps for missing directional keywords |
+| Text inside or touching a drawn shape | Compiles silently | Applies the Boundary Rule: 0.4cm minimum clearance from every circle, rectangle, or filled shape |
+| Two Bézier curves crossing each other | No warning | Checks bend direction compatibility across nearby arrows |
+| `scale=0.8` shrinks coordinates but not text | Geometrically valid | Recalculates all gaps accounting for the scale factor |
+| Label clipped by slide margin | Within the page box | Margin check: every object ≥ 0.5cm from the slide edge |
+| Same diagram on multiple slides has inconsistent positions | Each instance compiles independently | Pass 0 cross-slide consistency check |
+
+## The six passes
+
+`/tikz` runs a fixed, ordered protocol. Each pass targets a specific class of collision. Full formulas, clearance tables, and worked examples live in [`tikz_rules.md`](tikz_rules.md) (in this folder).
+
+| Pass | What it checks |
+|---|---|
+| **Pass 0** | Cross-slide consistency — when the same diagram appears on multiple frames, colors, positions, and font sizes must be identical except for the deliberate change. |
+| **Pass 1** | Bézier curves first. Computes max curve depth from chord length and bend angle, adds 0.5cm safety margin, checks every label in the danger zone. Also checks for curves crossing other arrows. |
+| **Pass 2** | Edge label gap calculations. For every label between two nodes, estimates label width (character count × font size), compares to the usable gap, flags where width exceeds gap. |
+| **Pass 3** | Arrow-label positioning keywords. Every `node[...]{}` on an arrow must carry `above`, `below`, `left`, `right`, `anchor=`, `pos=`, or `midway`. |
+| **Pass 4** | Boundary Rule. For every drawn shape, computes the boundary and flags any label within 0.4cm. Same rule applies to matplotlib / ggplot2 patches. |
+| **Pass 5** | Margin check. Minimum clearances enforced across labels, axes, arrows, and slide edges. |
+| **Pass 6** | **Debug bounding-box verification (skill-specific).** Add red outlines to every node, recompile, inspect for overlapping rectangles. The only reliable way to spot residual visual collisions Claude cannot eyeball. |
+
+## The re-audit rule
+
+**One collision fix almost always reveals another one.** After any change, `/tikz` re-runs Passes 0–5 on *all* TikZ figures in the file, not just the one that was touched. Moving a label to fix one collision can push it into another node, or reveal a previously hidden overlap. The skill treats the audit as complete only when a full pass on the entire file returns zero violations *and* a subsequent `pdflatex` shows zero Overfull, Underfull, or font warnings.
+
+## Usage
+
+```
+/tikz path/to/deck.tex
+```
+
+`/tikz` will identify every `tikzpicture` environment in the file, run the six passes on each, and produce a report with exact line numbers for every violation. It applies fixes directly to the source file, then recompiles to verify.
+
+## When to use it
+
+- **Always after `/beautiful_deck`** — the skill invokes `/tikz` automatically as part of the visual cleanup step. Because Step 4.4 now writes safe TikZ from the start, `/tikz` should find few or no issues in new decks. Re-run manually after any significant edit to a diagram.
+- **After any TikZ edit** — adding a new node, changing a bend angle, repositioning a label. Don't trust visual inspection alone; run the math.
+- **Before shipping a deck** — final pre-flight check.
+- **When a diagram "looks wrong" but you can't say why** — `/tikz` will find the exact measurement causing the discomfort.
+- **On TikZ written outside of `/beautiful_deck`** — legacy diagrams, inherited decks, hand-written TikZ. Expect more findings and more iteration.
+
+## Known limitations
+
+- **Cannot fix autosized nodes reliably.** If a `\node` has no explicit `minimum width`/`minimum height`, its rendered dimensions depend on text content and font — information `/tikz` can only estimate. The fix is upstream: write explicit dimensions.
+- **`scale` factor creates invisible collisions.** `scale=0.55` shrinks coordinates but not text. Compensation is fragile. The fix is upstream: never use `scale` on complex diagrams.
+- **Math-mode label widths.** `$\hat{\beta}_{it}$` is wider than character-count estimates suggest. Overestimate by 20–30%, or measure with a test compile.
+
+## Files in this skill
+
+- [`SKILL.md`](SKILL.md) — the operational checklist Claude follows when you invoke `/tikz`. Slimmed to delegate formulas to `tikz_rules.md`.
+- [`tikz_rules.md`](tikz_rules.md) — the canonical formula reference (every pass, every clearance, every worked example). **Also read by `/beautiful_deck` Step 4.4** as its generation-time rule book — single source of truth shared between the two skills.
+
+## Dependency note
+
+`/tikz` and `/beautiful_deck` share the rule book in this folder. If you install `/beautiful_deck` without `/tikz`, Step 4.4 will fail to find `tikz_rules.md`. Install both, or update the path reference in `beautiful_deck/SKILL.md`.
+
+## Related skills
+
+- **`/beautiful_deck`** — invokes `/tikz` automatically as part of the visual cleanup step during end-to-end deck creation. Also reads `tikz_rules.md` from this folder for generation-time prevention (Step 4.4).
+- **`/referee2`** (deck mode) — reads `tikz_rules.md` from this folder for margin and curve-clearance rules during slide audits.
+
+## The philosophy
+
+The common failure mode in academic decks is not "I couldn't make this figure" — it's "the figure compiles, looks mostly right, and has one subtle overlap that distracts the audience every time they look at it." Those overlaps are invisible to LaTeX and invisible to the author because they've stared at the diagram for hours.
+
+`/tikz` was originally written as the sole defense against these overlaps. Experience showed that a repair-only approach is insufficient — Claude reads the formulas and *simulates* having done the calculation, but doesn't always execute them rigorously. The breakthrough was recognizing that **prevention is worth ten repair passes**: writing safe TikZ from the start (explicit dimensions, coordinate maps, no `scale`) eliminates most collision classes before `/tikz` ever runs.
+
+The current architecture reflects this: `/beautiful_deck` Step 4.4 is the upstream defense (using the same `tikz_rules.md` reference). `/tikz` is the downstream check. Together they catch what either alone would miss.

--- a/.claude/skills/tikz/SKILL.md
+++ b/.claude/skills/tikz/SKILL.md
@@ -1,166 +1,139 @@
 ---
 name: tikz
-description: Quick visual-collision check for figures — TikZ inside .tex files OR rendered .png/.jpg/.pdf figures from R/Python. Three checks only. (1) Bezier-curve label collisions via gap math. (2) Label-to-object whitespace. (3) Labels touching or running off the figure edge. These are the visual errors that compile cleanly — pdflatex never warns about them, ggsave never refuses to write them, so the agent that produced them does not know they are wrong. Use after generating any figure where visual correctness matters and you cannot eyeball it yourself.
-allowed-tools: Bash(grep*), Bash(ls*), Bash(file*), Bash(wc*), Read, Edit
-argument-hint: [path/to/file.tex | path/to/figure.png | path/to/figure.pdf]
+description: Audit and fix residual TikZ visual collisions in any .tex file. A downstream repair tool — not a safety net. The upstream defense is /beautiful_deck Step 4.4, which writes safe TikZ from the start. Use /tikz when labels overlap arrows, text sits on boxes, or arrows cross each other. Applies mathematical gap calculations and Bézier depth formulas — no eyeballing.
+allowed-tools: Bash(pdflatex*), Bash(grep*), Bash(ls*), Read, Edit, Glob
+argument-hint: [path/to/file.tex]
 ---
 
-# `/tikz`: narrow visual-collision check
+# TikZ Collision Audit
 
-A small, fast collision check for figures. Three checks. Catches the class of error that produces no warning, no error, no exit code — only a wrong-looking figure that the producing agent cannot see.
+**Purpose**: Find and fix residual visual collisions in TikZ figures in a given `.tex` file. Labels on arrows, text inside boxes, arrows crossing arrows — this skill catches them using measurement, not intuition.
 
-This skill replaced an earlier six-pass version that ran an entire-file re-audit after every fix. That version timed out on real decks. This version does **three checks, one pass, exits**. If you want more, run it again.
-
----
-
-## Step 1: Identify the input
-
-Routing depends on file type:
-
-| Extension | Mode | What gets checked |
-|---|---|---|
-| `.tex` | **Math mode** | TikZ source — gap calculations, coordinate distances |
-| `.png`, `.jpg`, `.jpeg` | **Visual mode** | Rendered raster — read the image, look |
-| `.pdf` (single-figure) | **Visual mode** | Same: read and look |
-| `.pdf` (multi-page deck) | **Refuse** | Out of scope. Run `/tikz` on the figure file or the standalone .tex. |
-
-If the user did not specify a file, ask. Do not guess.
+**The fundamental rule**: Claude cannot reliably eyeball where TikZ elements land. All placement must be verified mathematically before declaring it safe.
 
 ---
 
-## The three checks (both modes apply them, just differently)
+## Critical context: this is a repair tool, not the primary defense
 
-### Check 1 — Bezier curve label collisions
+`/tikz` runs **after** TikZ has been generated. It audits existing code and fixes what it finds. But it cannot reliably fix diagrams that were never built with measurement in mind.
 
-A curved arrow has an arc that bows away from the chord between its endpoints. If a label sits in that arc, it gets crossed by the line.
+**The upstream defense is `/beautiful_deck` Step 4.4**, which writes safe TikZ from the start: explicit node dimensions, directional keywords on every edge label, coordinate map comments, canonical templates, no `scale` on complex diagrams.
 
-### Check 2 — Label-to-object whitespace
+**When Step 4.4 was applied**: `/tikz` should find few or no issues. Run it as a check.
 
-Every text label needs at least 0.4 cm (or visible whitespace, in raster terms) between its bounding box and any drawn shape — node, axis, marker, bar.
-
-### Check 3 — Labels touching or running off the figure edge
-
-Every label has to be entirely inside the figure bounds, with at least 0.5 cm clearance from the edge. Labels at the right margin, top margin, or rotated y-axis labels are the typical offenders.
+**When Step 4.4 was NOT applied** (legacy TikZ, hand-written diagrams, inherited decks): `/tikz` does its best, but expect more findings, more iteration, and lower reliability on autosized nodes and scaled diagrams.
 
 ---
 
-## Math mode (for `.tex` files)
+## Step 1: Read the rule book
 
-For each `\begin{tikzpicture}` block:
+The full rule book — every formula, every clearance table, every worked example — lives at `~/.claude/skills/tikz/tikz_rules.md`. **Read it first.** This SKILL.md is the operational checklist; `tikz_rules.md` is the reference. Do not try to execute the audit from memory.
 
-### Check 1: Bezier curves
+The same rule book is read by `/beautiful_deck` Step 4.4 (generation-time prevention). Single source of truth.
+
+---
+
+## Step 2: Identify the file and run the pre-check
+
+If the user specified a file, use it. If not, ask. Then:
 
 ```bash
-grep -n "bend" [file].tex
+grep -n "tikzpicture\|begin{frame}\|node\|draw\|bend\|foreach" [file].tex | head -100
 ```
 
-For each curved arrow with `bend left=N` or `bend right=N`:
+Get a sense of scope: how many TikZ diagrams, how many frames, how many arrows.
 
+### Pre-check: were the generation rules followed?
+
+Quickly assess whether the TikZ was written safely:
+
+```bash
+grep -n "\\\\node" [file].tex | grep -v "minimum"   # autosized nodes
+grep -n "scale=" [file].tex                          # scale on tikzpicture
+grep -n "% Coordinate map\|% Node map\|% Layout" [file].tex   # coordinate maps
 ```
-chord_length = distance between the two endpoints (cm)
-max_depth    = (chord_length / 2) × tan(N / 2)
-safe_zone    = max_depth + 0.5 cm
-```
 
-| Bend angle | tan(angle/2) |
-|---|---|
-| 20° | 0.176 |
-| 30° | 0.268 |
-| 45° | 0.414 |
-| 60° | 0.577 |
-
-If any label coordinate is within `safe_zone` of the chord baseline (in the direction the curve bends): flag and propose a position outside the safe zone.
-
-### Check 2: Whitespace
-
-For each `\node` containing label text and each adjacent `\draw` shape (rectangle, circle, line):
-
-- Compute label center
-- Compute shape boundary
-- Required clearance: 0.4 cm
-
-If a label coordinate lands within 0.4 cm of a boundary: flag and propose moving it 0.4 cm outside.
-
-### Check 3: Edge clipping
-
-For each `\node`, `\draw`, `\fill`:
-
-- Note extreme x/y coordinates
-- Compare against `\useasboundingbox` if declared, otherwise the implicit canvas
-- If any element is within 0.5 cm of the figure edge: flag.
+- **Autosized nodes widespread** → repair reliability is lower. Upstream fix: add explicit dimensions. Consider doing that first.
+- **`scale` on complex diagram** → coordinates compress but text does not. Compensation in Passes 2–5 is fragile. Upstream fix: redesign at intended size.
+- **No coordinate map** → audit takes longer; spatial relationships must be reverse-engineered from code.
 
 ---
 
-## Visual mode (for `.png` / `.jpg` / single-figure `.pdf`)
+## Step 3: Run the six passes from `tikz_rules.md`
 
-Read the image. Inspect it visually — Claude is multimodal and can see the rendered figure directly. Apply the same three checks, scored by visible whitespace rather than measured distance:
+For each `tikzpicture` in the file, run all six passes **in order**. Follow the protocols and formulas in `tikz_rules.md` exactly — do not paraphrase or estimate.
 
-### Check 1: Curve label collisions
+| Pass | Target | Rule-book section |
+|---|---|---|
+| **0** | Cross-slide consistency | `tikz_rules.md` § Pass 0 |
+| **1** | Bézier curves — do this FIRST | `tikz_rules.md` § Pass 1 |
+| **2** | Edge-label gap calculations | `tikz_rules.md` § Pass 2 |
+| **3** | Arrow-label positioning keywords | `tikz_rules.md` § Pass 3 |
+| **4** | Boundary Rule (labels vs drawn shapes) | `tikz_rules.md` § Pass 4 |
+| **5** | Margin spacing | `tikz_rules.md` § Pass 5 |
 
-Any text that visibly intersects a curved line, arrow shaft, or smoothed regression line.
+Useful greps for each pass:
 
-### Check 2: Label-object overlap
-
-Any text that touches or overlaps a marker, bar, axis line, gridline, or other plot element. Includes legend boxes that overlap the plot area.
-
-### Check 3: Edge clipping
-
-Any label partially cut off by the image boundary, or running into the figure margin. Includes y-axis titles too close to the left edge, x-axis titles too close to the bottom, rotated tick labels overflowing.
-
-### Honest limitation
-
-Visual-mode detection is less reliable than math mode. Reliable: clipping, large overlaps. Less reliable: subtle whitespace violations under a few pixels. When the figure is high-stakes, also run `/tikz` on the source code (.R, .py, or .tex) that generated it — the source has signals the rendering does not.
-
-### Typical fixes by toolchain
-
-**ggplot2 (R)**:
-- Move legend: `theme(legend.position = "top")`
-- Crowded labels: `ggrepel::geom_text_repel()`
-- Edge clipping: `theme(plot.margin = margin(t=10, r=20, b=10, l=20))`
-- Long y-axis title: `theme(axis.title.y = element_text(margin = margin(r=10)))`
-
-**matplotlib (Python)**:
-- Auto-padding: `plt.tight_layout()`
-- Save with bounds: `plt.savefig(..., bbox_inches='tight')`
-- Move legend: `ax.legend(bbox_to_anchor=(1.02, 1), loc='upper left')`
-
-**TikZ (LaTeX)**:
-- Add `\useasboundingbox` to declare canvas explicitly
-- Use `node[anchor=...]` to control label placement relative to coordinate
-- For curves, place label as a separate `\node at (midpoint)` outside the arc, not as inline edge label
-
----
-
-## Output
-
-Report findings as a structured list. Do not enter a repair loop.
-
-```
-[file] — quick check complete
-
-Bezier collisions:    N
-Whitespace collisions: M
-Edge clipping:        K
-
-Findings:
-  - <location>: <description>. Fix: <proposed change>.
-  - ...
+```bash
+grep -n "node.*{" [file].tex | grep -v "^[[:space:]]*%"        # Pass 0 candidates
+grep -n "bend" [file].tex                                       # Pass 1 — every curve
+grep -n "node\[" [file].tex | grep -v "above\|below\|left\|right\|anchor\|pos\|midway\|near"   # Pass 3 violations
 ```
 
-Then **stop**. The user reviews and edits. If they want a deeper look at a specific element, they invoke `/tikz` again on that scope.
+---
+
+## Step 4: Pass 6 — Debug bounding-box verification (skill-specific)
+
+This pass is unique to `/tikz` (it does not appear in `tikz_rules.md` because it's an audit step, not a generation rule).
+
+**Do NOT attempt to visually inspect the PDF by "eyeballing."** Claude cannot reliably see TikZ collisions in rendered PDFs. Instead:
+
+1. **Temporarily add red debug outlines** around every node:
+   ```latex
+   % DEBUG — add to preamble temporarily, remove before shipping
+   \tikzset{every node/.append style={draw=red, very thin}}
+   ```
+
+2. **Compile and inspect**: overlapping bounding boxes are now visible as overlapping red rectangles. Collisions become structurally obvious rather than visually estimated.
+
+3. **For each red-box overlap**: go back to the source, fix coordinates or dimensions, recompile.
+
+4. **Remove the debug line** before declaring the audit complete.
 
 ---
 
-## What this skill does NOT do
+## Step 5: Fix, recompile, repeat
 
-- It does not iterate. One pass, one report, exit.
-- It does not re-audit the whole file after a fix. That's the quadratic blowup that killed the previous version.
-- It does not run `pdflatex` in a loop.
-- It does not eyeball multi-page PDFs. PDF mode is single-figure only; for decks, point it at the source `.tex` instead.
-- It does not perform cross-slide consistency checks, autosized-node detection, scale-factor compensation, or the four other passes the previous version did. If you want those, the prior behavior is in git history at `~/mixtapetools/` HEAD~ before this commit.
+After making fixes:
+
+```bash
+pdflatex -interaction=nonstopmode [file].tex 2>&1 | grep -E "Overfull|Underfull|Error|Warning"
+```
+
+Must return zero lines. Fix any new warnings introduced by repositioning. Repeat until clean.
 
 ---
 
-## Why narrow
+## Step 6: Re-audit the ENTIRE file after any fix
 
-Visual errors that don't produce compile errors are the class Claude Code fundamentally cannot detect during normal work. The agent compiles, sees no warnings, declares done — and the figure has a label sitting on a curve. Three checks, focused on the three errors that compile cleanly, finishing in under five minutes per figure. That is the entire value proposition.
+One collision fix often reveals a second one nearby, or introduces a new label that crowds a different object. After every change, re-run Passes 1–5 on **all** TikZ figures in the file — not just the one you just touched.
+
+```bash
+grep -c "tikzpicture" [file].tex
+```
+
+That count is how many diagrams need a clean bill of health.
+
+---
+
+## Known limitations
+
+These are the cases where `/tikz` is least reliable. The better fix is almost always upstream (rewrite the TikZ safely) rather than downstream (try to repair it).
+
+| Limitation | Why it's hard | Upstream fix |
+|---|---|---|
+| **Autosized nodes** (no `minimum width`/`minimum height`) | Rendered dimensions depend on text + font — `/tikz` can only estimate | Add explicit dimensions (`tikz_rules.md` Rule 1) |
+| **`scale` on complex diagrams** | Coordinates shrink but text does not; gap calc compensation is fragile | Redesign at intended size (`tikz_rules.md` Rule 5) |
+| **Math-mode label widths** | `$\hat{\beta}_{it}$` is wider than character-count × width/char suggests | Overestimate by 20–30% or measure with a test compile |
+| **Nested `tikzpicture` environments** | Coordinate systems interact unpredictably | Flatten into a single environment |
+| **`\foreach` loops generating many nodes** | Per-iteration gap checks; easy to miss one | Write explicit nodes for small counts; check loop bounds for large counts |

--- a/.claude/skills/tikz/tikz_rules.md
+++ b/.claude/skills/tikz/tikz_rules.md
@@ -1,0 +1,347 @@
+# TikZ & Figure Anti-Collision Rules
+
+These rules prevent rendering errors — text on top of arrows, arrows crossing arrows, labels spilling over boxes. The compiler catches none of these. You must catch them yourself. **These rules apply to BOTH TikZ diagrams AND matplotlib/Python figures.**
+
+---
+
+## THE WORKFLOW: Bézier First, Everything Else Second
+
+Every time you create or edit TikZ in a deck, follow this order. Do not skip steps. Do not audit only the slide you just touched — audit the entire deck.
+
+### Pass 0: Cross-slide consistency
+
+Before checking geometry, check continuity. When the same diagram, cycle, or visual element appears on more than one slide:
+
+1. **Colors must match.** If "Inspect" is Slate on slide 31, it must be Slate on slide 32. Grep for repeated node names or labels across frames.
+2. **Layout must match.** Same nodes at same positions, same spacing, same font sizes.
+3. **Deliberate changes must be the ONLY changes.** If slide 32 adds a red rectangle to highlight the bottleneck, that should be the only difference from slide 31. Nothing else moves, recolors, or resizes.
+
+This catches continuity errors that are invisible when looking at one slide in isolation but obvious when flipping between consecutive slides.
+
+```bash
+# Find all frames that share the same node names
+grep -n "node.*draft\|node.*compile\|node.*inspect" [file].tex
+```
+
+For each group of slides sharing elements, verify color and position consistency.
+
+---
+
+### Pass 1: Find and fix all Bézier curves
+
+```bash
+grep -n "bend" [file].tex
+```
+
+For EACH curved arrow found:
+
+**Step 1.** Identify the two endpoints and the bend angle.
+
+**Step 2.** Calculate max curve depth:
+```
+max_depth = (chord_length / 2) × tan(bend_angle / 2)
+```
+
+**Step 3.** Calculate safe distance:
+```
+safe_distance = max_depth + 0.5cm
+```
+
+**Step 4.** Check every label near the curve. Any label closer than `safe_distance` to the baseline (in the direction the curve bends) MUST be moved.
+
+**Step 5.** Check every other arrow in the same figure. Does the curve cross any of them? If the curve bends downward and there's a vertical arrow in the middle of the diagram, they WILL cross. Fix: re-route the curve to bend the other direction (`bend right` instead of `bend left`, or vice versa).
+
+### Common bend values for quick reference
+
+| Bend angle | tan(angle/2) | Multiplier for half-chord |
+|-----------|-------------|--------------------------|
+| 20° | 0.176 | × 0.18 |
+| 25° | 0.222 | × 0.22 |
+| 30° | 0.268 | × 0.27 |
+| 35° | 0.315 | × 0.32 |
+| 40° | 0.364 | × 0.36 |
+| 45° | 0.414 | × 0.41 |
+
+Example: Arrow across 8.4cm with `bend left=35`:
+- Half-chord = 4.2
+- Depth = 4.2 × 0.315 = **1.32cm**
+- Safe distance = 1.32 + 0.5 = **1.82cm**
+- Any label must be at y ≤ -1.82 (not -1.2, not -1.5)
+
+### Pass 2: Gap calculations for labels between nodes
+
+For every label positioned between two nodes:
+
+```
+Available gap = (center-to-center distance) - (half-width of node A) - (half-width of node B)
+Usable space  = Available gap - 0.6cm (0.3cm padding each side)
+```
+
+Estimate label width:
+
+| Font size | Width per character |
+|-----------|-------------------|
+| `\scriptsize` | 0.10cm |
+| `\footnotesize` | 0.12cm |
+| `\small` | 0.15cm |
+| `\normalsize` | 0.18cm |
+
+Bold: +10%. Monospace: +15%.
+
+If estimated label width > usable space: collision guaranteed. Move the label above/below or shorten it.
+
+For short arrows between boxes, the gap calculation is not enough. A label can fit horizontally and still crowd the arrow or touch the endpoint boxes. When the usable gap is less than 2.5cm, or when the label uses more than half of the usable gap, prefer a standalone label node with explicit coordinates and dimensions. Draw the arrow separately.
+
+```latex
+% Preferred for short arrows between boxes
+\node[font=\scriptsize, align=center, minimum width=1.8cm, minimum height=0.35cm]
+  at (2.2,0.95) {package the prompt};
+\draw[->] (A) -- (B);
+```
+
+Use inline edge labels only when both checks pass:
+
+1. Estimated label width is comfortably below usable gap, with at least 0.3cm padding on both sides.
+2. The label's rendered box clears the arrow line and both endpoint boxes by at least 0.3cm.
+
+### Pass 3: Arrow label positioning
+
+Every inline arrow label must have a positional keyword:
+
+```latex
+% GOOD only when Pass 2 clearance also passes
+\draw[->] (A) -- (B) node[midway, above] {label};
+
+% BAD — label sits ON the arrow
+\draw[->] (A) -- (B) node[midway] {label};
+```
+
+Horizontal arrows: `above` or `below`.
+Vertical arrows: `left` or `right`.
+Diagonal: whichever side has more space.
+
+For short arrows, prefer the standalone-node pattern from Pass 2. Positional keywords are necessary but not sufficient: `node[midway, above]` can still collide with endpoint boxes when the arrow is short or the label is long.
+
+### Pass 4: Labels vs. drawn shapes (the Boundary Rule)
+
+**Problem this solves**: Text placed at hardcoded coordinates that collide with the edge of a circle, rectangle, or filled region. The compiler gives zero warnings for these — they only show up visually.
+
+**The rule**: Every label placed near a drawn geometric shape must have its coordinate verified against the shape's computed boundary. Never place text at a coordinate chosen for aesthetic alignment (e.g., "same y-height as another label") without checking whether that coordinate clears the shape it's near.
+
+**For circles**: `\draw (cx, cy) circle (r);` → boundary extends from `cy - r` to `cy + r`. Any label must be at least **0.4cm** outside the boundary (if external) or at least **0.4cm** inside (if internal).
+
+```
+% WRONG — label at y=2.0 sits exactly on boundary of circle with center (4, 0.5) radius 1.5
+\draw (4, 0.5) circle (1.5cm);  % top edge at y = 0.5 + 1.5 = 2.0
+\node at (4, 2.0) {Sample};     % COLLISION: y = top edge
+
+% RIGHT — label 0.4cm above the top edge
+\node at (4, 2.4) {Sample};     % 2.0 + 0.4 = 2.4 ✓
+```
+
+**For rectangles / FancyBboxPatch**: bottom-left `(x, y)` with width `w` and height `h` → top edge at `y + h`. Same 0.4cm clearance rule.
+
+**Critical corollary — don't match y-coordinates across different shapes**: If two shapes have different sizes, a single y-coordinate that's safe for one may collide with the other. Always compute boundaries independently for each shape.
+
+**For matplotlib/Python figures**: The same principle applies. When positioning `ax.text()` calls near `FancyBboxPatch` or `Circle` objects, compute the patch boundary and verify clearance. Text with `va='center'` extends roughly half its font height above and below the anchor — account for this.
+
+**Sub-rule: Bézier-first for matplotlib arrows (the arc3 formula).** The TikZ Bézier workflow (Pass 1) has an exact equivalent for matplotlib's `arc3` connectionstyle. You MUST compute curve positions before placing labels — the same "Claude cannot eyeball where a curve passes" rule applies to Python figures.
+
+**Matplotlib arc3 control point formula:**
+```python
+# For ax.annotate with connectionstyle='arc3,rad=R':
+# Start: (x1, y1), End: (x2, y2)
+dx, dy = x2 - x1, y2 - y1
+cx = (x1 + x2) / 2 + R * dy     # control point x
+cy = (y1 + y2) / 2 - R * dx     # control point y
+```
+
+**To find where the curve passes at any x-coordinate**, use the quadratic Bézier formula:
+```python
+B(t) = (1-t)²·P0 + 2(1-t)t·P1 + t²·P2,  t ∈ [0,1]
+```
+Solve for t at the desired x, then compute y(t). Use numerical sampling if needed.
+
+**Labeling arrows in matplotlib:** Once you know the curve's y-position at the label's x-coordinate, offset the label perpendicular to the curve with a white-background bbox:
+```python
+# Compute where curve passes at gap midpoint
+cx, cy = arc3_control_point(x1, y1, x2, y2, rad)
+t_mid = find_t_for_x(gap_mid_x, x1, cx, x2)
+curve_y = bezier_y_at_t(t_mid, y1, cy, y2)
+
+# Place label ABOVE the computed curve position
+ax.text(gap_mid_x, curve_y + 0.35, label, ha='center', va='bottom',
+        bbox=dict(facecolor='white', edgecolor='none', alpha=0.8, pad=1))
+```
+
+**Label offset direction:**
+- Arrow curves upward → label above (`va='bottom'`)
+- Arrow curves downward → label below (`va='top'`)
+- Arrow is straight → label above (`va='bottom'`)
+
+**Never guess arrow positions.** Every attempt to place labels by visual intuition or simple offsets from endpoints will fail. The formula is the only reliable method — just as in TikZ.
+
+**Sub-rule: Anchor-based centering of text pairs.** When multiple text elements (title + math, header + body) are placed inside a single container, do NOT use `va='center'` for both at symmetric y-offsets — this fails because multi-line text extends further from its anchor than single-line text, creating visual asymmetry even when coordinates are symmetric.
+
+Instead, **anchor both elements outward from the container's center**:
+- Upper element: `va='bottom'` at `center_y + small_gap` (text grows upward)
+- Lower element: `va='top'` at `center_y - small_gap` (text grows downward)
+
+This ensures true visual centering regardless of how many lines each element has.
+
+```python
+# WRONG — symmetric coordinates but visually asymmetric
+title_y = box_mid_y + 0.7   # 2-line title with va='center' → top-heavy
+math_y  = box_mid_y - 0.7   # 1-line math with va='center' → too low
+
+# RIGHT — anchor-based, text grows outward from center
+ax.text(x, box_mid_y + 0.15, 'Title\nLine 2', va='bottom', ...)  # grows UP
+ax.text(x, box_mid_y - 0.15, r'$math$',       va='top', ...)     # grows DOWN
+```
+
+### Pass 5: Margin spacing and everything else
+
+**THE MARGIN RULE (mandatory):** Every pair of distinct visual objects — labels, arrows, boxes, axis lines, tick marks, curve endpoints — must have **visible margin space** between them. No object should touch or visually collide with another. Minimum clearances:
+
+| Object pair | Minimum clearance |
+|---|---|
+| Label ↔ label | 0.3cm |
+| Label ↔ axis line | 0.3cm |
+| Label ↔ arrow | 0.3cm |
+| Arrow origin ↔ box edge | 0.15cm |
+| Label ↔ drawn shape boundary | 0.4cm (see Pass 4) |
+| Any object ↔ slide edge | 0.5cm |
+
+When two labels would overlap or touch at their intended positions, move one of them — offset it, anchor it differently, or shorten the text. **Never allow two objects to share the same visual space.** This rule catches the most common TikZ errors: labels sitting on axis lines, $\mu$ markers overlapping x-axis descriptions, arrow origins crowding box edges.
+
+Additional checks:
+- Multi-line nodes have `align=center`?
+- No nodes clipped by slide edges (0.5cm margin)?
+- If scaled: nodes scaled too, not just coordinates?
+- Arrow colors and stealth sizes consistent?
+- No two labels overlap?
+
+### Pass 5b: Plotted curves (normal distributions, arbitrary functions)
+
+**Problem this solves**: Labels, boxes, arrows, and other objects placed near plotted curves (e.g., `\draw plot` with mathematical functions) that overlap because the curve's position was never calculated. TikZ `plot` commands generate curves that the compiler renders but never checks for collisions. You must calculate curve positions yourself.
+
+**The rule**: For every plotted curve, compute its y-value at every x-coordinate where another object exists. Verify clearance.
+
+**For normal/Gaussian curves** of the form `plot ({A*\x}, {B + C*exp(-\x*\x/2)})`:
+- Peak is at x=0: `y_peak = B + C`
+- At any TikZ x-coordinate X: `x_norm = X / A`, then `y = B + C * exp(-x_norm^2 / 2)`
+- Every label, box edge, or arrow within the x-domain of the curve must clear the computed y-value by at least **0.3cm**
+
+**Example**: Curve `plot ({1.5*\x}, {0.3 + 2.0*exp(-\x*\x/2)})`:
+- Peak: y = 0.3 + 2.0 = 2.3
+- At x=1.5 (one SD): y = 0.3 + 2.0*0.607 = 1.51
+- At x=3.0 (two SD): y = 0.3 + 2.0*0.135 = 0.57
+- A label at y=3.0 near x=0 clears the peak by 0.7 ✓
+- A box with bottom edge at y=3.6 clears the peak by 1.3 ✓
+
+**Common failure**: Setting amplitude too high so the curve peak penetrates nearby boxes, or placing labels at y-positions that look clear in your head but sit inside the curve. Always compute, never eyeball.
+
+### Pass 6: Open the PDF and visually confirm
+
+---
+
+## REFERENCE: The Individual Rules
+
+### Rule 1: Gap Calculation (see Pass 2 above)
+
+Worked example — the "via the terminal" problem:
+- Two boxes: left at x=0 (5cm wide), right at x=6.5 (5cm wide)
+- Edge-to-edge gap: 4.0 - 2.5 = 1.5cm
+- Usable: 1.5 - 0.6 = 0.9cm
+- Label "via the terminal" = 16 chars × 0.10 = 1.6cm
+- 1.6 > 0.9: collision. Fix: move label above both boxes.
+
+### Rule 2: Positional Keywords (see Pass 3 above)
+
+### Rule 3: Minimum Spacing
+
+| Between | Minimum |
+|---------|---------|
+| Node edge to node edge | 0.8cm |
+| Label to any line/arrow | 0.15cm |
+| Node edge to slide margin | 0.5cm |
+| Stacked labels (vertically) | 0.3cm |
+
+### Rule 4: Multi-line Nodes
+
+`\\` in a node requires `align=center` (or `align=left`). Without it: "Not allowed in LR mode" error. Set `text width` 15% wider than your estimate.
+
+### Rule 5: Scale Shrinks Coordinates But Not Text
+
+`scale=0.8` makes a 2cm gap into 1.6cm, but text stays full size. Always use:
+```latex
+\begin{tikzpicture}[scale=0.8, every node/.style={scale=0.8}]
+```
+Or better: don't scale. Design at intended size.
+
+### Rule 6: Staggering Crowded Labels
+
+- Alternate `above`/`below` for consecutive arrow labels
+- Use `pos=0.3` and `pos=0.7` instead of `midway` for parallel arrows
+- `near start` and `near end` for very crowded diagrams
+
+### Rule 7: Bézier Curves (see Pass 1 above)
+
+The fundamental problem: Claude cannot eyeball where a curve passes. The formula is the only reliable method. DO NOT trust intuition on curved arrows.
+
+### Rule 8: Arrows Crossing Arrows
+
+A curved return arrow bending downward WILL cross any vertical arrow in the middle of the diagram. Fix: route the return arrow above (`bend right` instead of `bend left` when going right-to-left).
+
+### Rule 9: Full-Deck Re-Audit
+
+After ANY TikZ fix, re-audit EVERY TikZ figure in the deck. The same error pattern repeats across slides because the same code structure was reused. `grep -n "bend"` finds all curves. Check each one. This takes 2 minutes. Skipping it costs the user's trust.
+
+---
+
+## Common Collision Patterns
+
+1. **Label between wide boxes**: Text exceeds gap. Fix: move above/below.
+2. **Timeline with era labels**: Adjacent labels overlap. Fix: stagger above/below.
+3. **Flow diagram with many arrows**: Labels pile up. Fix: label only non-obvious transitions.
+4. **Node near slide edge**: Text extends past boundary. Fix: explicit `text width`, 0.5cm margin.
+5. **Return arrow crossing vertical branch**: Curve passes through another arrow. Fix: bend the other direction.
+6. **Label in curved arrow's path**: Label placed "below" the baseline but inside the curve's sweep. Fix: use the depth formula, add 0.5cm safety margin.
+
+---
+
+## Matplotlib Bézier Helper Functions (Copy-Paste Template)
+
+When generating ANY Python/matplotlib figure with curved arrows (`arc3`), include these helper functions at the top of the script. They compute exact curve positions so labels can be placed with precision.
+
+```python
+import numpy as np
+
+def arc3_control_point(x1, y1, x2, y2, rad):
+    """Compute the quadratic Bézier control point for matplotlib's arc3 connectionstyle.
+    Formula from matplotlib source: cx = mid_x + rad*dy, cy = mid_y - rad*dx
+    """
+    dx, dy = x2 - x1, y2 - y1
+    cx = (x1 + x2) / 2 + rad * dy
+    cy = (y1 + y2) / 2 - rad * dx
+    return cx, cy
+
+def find_t_for_x(target_x, x1, cx, x2, num_samples=1000):
+    """Find the Bézier parameter t where x(t) ≈ target_x."""
+    ts = np.linspace(0, 1, num_samples)
+    xs = (1 - ts)**2 * x1 + 2 * (1 - ts) * ts * cx + ts**2 * x2
+    return ts[np.argmin(np.abs(xs - target_x))]
+
+def bezier_y_at_t(t, y1, cy, y2):
+    """Y-coordinate of quadratic Bézier at parameter t."""
+    return (1 - t)**2 * y1 + 2 * (1 - t) * t * cy + t**2 * y2
+
+# Usage: Label an arc3 arrow at the midpoint of the gap
+# cx, cy = arc3_control_point(start_x, start_y, end_x, end_y, rad)
+# t_mid = find_t_for_x(gap_mid_x, start_x, cx, end_x)
+# curve_y = bezier_y_at_t(t_mid, start_y, cy, end_y)
+# ax.text(gap_mid_x, curve_y + 0.35, label, ha='center', va='bottom',
+#         bbox=dict(facecolor='white', edgecolor='none', alpha=0.8, pad=1))
+```
+
+**When to use:** Every time a matplotlib figure has `connectionstyle='arc3'` AND labels near those arrows. For straight arrows (`rad=0`), the curve position is just linear interpolation — but still compute it, don't guess.

--- a/skills/tikz/README.md
+++ b/skills/tikz/README.md
@@ -1,74 +1,141 @@
-# `/tikz` — Quick visual-collision check
+# TikZ Collision Audit (`/tikz`)
 
-> A narrow check for the visual errors that compile cleanly. Three checks, one pass, exits.
+> **A repair tool for residual TikZ collisions — not a safety net for bad generation.**
 
-`/tikz` catches the class of figure error that produces no warning, no compile error, and no exit code — only a wrong-looking figure that the producing agent cannot see. Labels sitting on curved arrows. Text touching node boundaries. Y-axis titles clipped by the figure margin. `pdflatex` does not warn about any of these. `ggsave` does not refuse to write them. The agent that produced them does not know they are wrong.
+`/tikz` catches what `pdflatex` doesn't: labels sitting on arrows, text bleeding into box edges, Bézier curves passing through other labels, arrows pointing to the wrong node. LaTeX reports none of these. Humans usually miss them on first review. `/tikz` finds them by computing the actual geometry.
 
-This skill replaced an earlier six-pass version that re-audited the entire file after every fix. That version timed out on real decks because the work was quadratic in the number of figures. This version does **three checks, one pass, exits**.
+## The critical distinction: prevention vs. repair
 
-## What it does
+**`/tikz` is a repair tool.** It runs measurement-based checks on existing TikZ code and fixes what it finds. But it cannot reliably fix diagrams that were never built with measurement in mind — autosized nodes, missing directional keywords, `scale` factors that compress coordinates but not text. These upstream generation problems produce collisions that are structurally unfixable by any audit pass.
 
-Three checks, applied to either TikZ source or rendered figure:
+**The upstream defense is `/beautiful_deck` Step 4.4**, which writes safe TikZ from the start: explicit node dimensions, coordinate maps, directional keywords on every edge label, canonical templates for common diagram types, and a strict prohibition on `scale` for complex diagrams. When Step 4.4 does its job, `/tikz` has little to find. When Step 4.4 is skipped — or when you're auditing TikZ that was written outside of `/beautiful_deck` — `/tikz` does its best, but the success rate depends entirely on how the TikZ was generated.
 
-1. **Bezier curve label collisions.** A label inside the arc of a curved arrow. Math mode computes `(chord_length / 2) × tan(bend_angle / 2)` and adds a 0.5cm safety margin; visual mode reads the rendered image and looks.
-2. **Label-to-object whitespace.** A label that touches or overlaps a node, axis, marker, bar, or other plot element. 0.4cm minimum clearance.
-3. **Edge clipping.** A label running off the figure edge or sitting too close to the boundary. 0.5cm minimum clearance.
+**The pipeline**: prevention (Step 4.4) → compile (Step 6) → residual repair (`/tikz`, Step 7).
 
-That's it. No cross-slide consistency. No autosized-node detection. No scale-factor compensation. If you want those, the previous behavior is in git history.
+## The fundamental rule
 
-## Two modes
+**Claude cannot reliably eyeball where TikZ elements land.** Anywhere a label's position depends on arithmetic — gap widths, curve depths, scale factors, node boundaries — the placement must be verified mathematically before it is declared safe. Estimating "looks about right" is the failure mode. `/tikz` replaces estimation with formulas.
 
-| Input file | Mode | How it works |
+## What it catches
+
+| Problem | Why LaTeX misses it | How `/tikz` catches it |
 |---|---|---|
-| `.tex` | **Math mode** | Greps the source for `bend`, `\node`, `\draw`. Computes coordinates and gaps. Reports collisions with proposed fixes. |
-| `.png`, `.jpg`, `.jpeg` | **Visual mode** | Reads the image. Inspects the rendered figure directly using Claude's multimodal vision. |
-| `.pdf` (single-figure) | **Visual mode** | Same. |
-| `.pdf` (multi-page deck) | **Refused** | Out of scope. Point `/tikz` at the source `.tex` instead. |
+| Label overlaps a Bézier curve | Curve geometry is runtime-computed | Computes `max_depth = (chord/2) × tan(bend/2)` and checks labels against the safe zone |
+| Edge label between two nodes is wider than the gap | LaTeX places it anyway; the text just runs under the next node | Compares estimated text width to the usable gap (`center-to-center − half-width(A) − half-width(B) − 0.6cm padding`) |
+| `node[...]{text}` on an arrow without `above`/`below`/`left`/`right` | Valid syntax | Greps for missing directional keywords |
+| Text inside or touching a drawn shape | Compiles silently | Applies the Boundary Rule: 0.4cm minimum clearance from every circle, rectangle, or filled shape |
+| Two Bézier curves crossing each other | No warning | Checks bend direction compatibility across nearby arrows |
+| `scale=0.8` shrinks coordinates but not text | Geometrically valid | Recalculates all gaps accounting for the scale factor |
+| Label clipped by slide margin | Within the page box | Margin check: every object ≥ 0.5cm from the slide edge |
+| Same diagram on multiple slides has inconsistent positions | Each instance compiles independently | Pass 0 cross-slide consistency check |
 
-Honest limitation on visual mode: large overlaps and edge clipping are caught reliably; subtle whitespace violations under a few pixels may be missed. For high-stakes figures, run `/tikz` on both the source code and the rendered output.
+## The six passes
 
-## Why narrow
+`/tikz` runs a fixed, ordered protocol. Each pass targets a specific class of collision.
 
-The whole point is the class of error that compile-clean processes cannot detect. The agent runs `pdflatex`, sees zero errors, declares done — and the figure has a label sitting on a curve. Three checks, focused on those three errors, finishing in a few minutes per figure. That is the entire value proposition. Anything broader, and the skill spends its runtime on diagnostics that don't catch this specific failure.
+| Pass | What it checks |
+|---|---|
+| **Pass 0** | **Cross-slide consistency** — when the same diagram appears on multiple frames, colors, positions, and font sizes must be identical except for the deliberate change (a new highlight, a new node revealed). |
+| **Pass 1** | **Bézier curves first.** Every `bend` in the file. Computes the maximum curve depth from the chord length and bend angle, adds a 0.5cm safety margin, and checks every label in the danger zone. Also checks for curves crossing other arrows. |
+| **Pass 2** | **Edge label gap calculations.** For every label placed between two nodes, estimates the label's width in cm (from character count and font size), compares to the usable gap, and flags any case where width exceeds the gap. Most common fix: break the label out as a standalone `\node` above the arrow midpoint. |
+| **Pass 3** | **Arrow label positioning keywords.** Every `node[...]{}` on an arrow must carry `above`, `below`, `left`, `right`, `anchor=`, `pos=`, or `midway`. Anything missing sits ON the arrow line. Greps for violations. |
+| **Pass 4** | **Boundary Rule.** For every drawn shape, computes the boundary and flags any label within 0.4cm of it. Also applies to matplotlib / ggplot2 patches and `FancyBboxPatch` objects — the same rule. |
+| **Pass 5** | **Margin check.** Minimum clearances: label ↔ label 0.3cm; label ↔ axis 0.3cm; label ↔ arrow 0.3cm; arrow origin ↔ box edge 0.15cm; label ↔ shape boundary 0.4cm; any object ↔ slide edge 0.5cm. |
+
+A final **Pass 6** opens the PDF and asks for a visual sanity check — trust the math, then trust your eyes.
+
+## Minimum clearances
+
+These are the measurements the skill enforces. Everything the pdflatex log cannot see, but everything an attentive reader does see:
+
+| Pair | Minimum clearance |
+|---|---|
+| Label ↔ label | 0.3 cm |
+| Label ↔ axis line | 0.3 cm |
+| Label ↔ arrow | 0.3 cm |
+| Arrow origin ↔ box edge | 0.15 cm |
+| Label ↔ shape boundary (circle, rectangle, fill) | 0.4 cm |
+| Any object ↔ slide edge | 0.5 cm |
+
+## Font-to-width reference (for gap calculations)
+
+Text width estimation in Pass 2:
+
+| Font | Width per character |
+|---|---|
+| `\scriptsize` | 0.10 cm |
+| `\footnotesize` | 0.12 cm |
+| `\small` | 0.15 cm |
+| `\normalsize` | 0.18 cm |
+| Bold | +10% |
+
+## The bend-angle → curve-depth table
+
+For Pass 1 Bézier calculations: `max_depth = (chord_length / 2) × tan(bend / 2)`.
+
+| Bend angle | tan(angle/2) |
+|---|---|
+| 20° | 0.176 |
+| 25° | 0.222 |
+| 30° | 0.268 |
+| 35° | 0.315 |
+| 40° | 0.364 |
+| 45° | 0.414 |
+
+## The re-audit rule
+
+**One collision fix almost always reveals another one.** After any change, `/tikz` re-runs Passes 1–5 on *all* TikZ figures in the file, not just the one that was touched. Moving a label to fix one collision can push it into another node, or reveal a previously hidden overlap on a nearby arrow. The skill treats the audit as complete only when a full pass on the entire file returns zero violations *and* a subsequent `pdflatex` shows zero Overfull, Underfull, or font warnings.
+
+## Common patterns and fast fixes
+
+Catalog of the collision patterns Scott has seen most often in his own decks:
+
+| Pattern | Symptom | Fix |
+|---|---|---|
+| Label between wide boxes | Text bleeds into box edge | Move label above the arrow as a standalone `\node` |
+| "Step 1" / "Step 2" labels on flow diagrams | Labels overlap box text | Place labels *above* the arrow band, not as edge labels |
+| Diagonal arrow label at `below right` | Label lands inside another box | Use `pos=0.55` and compute the landing position |
+| Return curve crossing a vertical arrow | Arrows intersect visually | Reverse bend direction (`bend left` ↔ `bend right`) |
+| `scale=0.8` used on a complex diagram | Text is large, gaps are small | Redesign at the intended size; avoid `scale` on complex figures |
+| Slope label on a regression line | Label sits on top of the line | Use `node[anchor=west]` at a point 0.3cm off the line end |
+| `\\` inside `\textcolor{}` | Hbox overflow | Break into two separate `\textcolor` calls on separate lines |
 
 ## Usage
 
 ```
 /tikz path/to/deck.tex
-/tikz figures/regression_plot.png
-/tikz figures/standalone_diagram.pdf
 ```
 
-If you invoke without a file, the skill asks. It does not guess.
+`/tikz` will identify every `tikzpicture` environment in the file, run the six passes on each, and produce a report with exact line numbers for every violation. It applies fixes directly to the source file, then recompiles to verify.
 
-## Output
+## When to use it
 
-```
-[file] — quick check complete
+- **Always after `/beautiful_deck`** — the skill invokes `/tikz` automatically as part of the visual cleanup step (Step 7). Because Step 4.4 now writes safe TikZ from the start, `/tikz` should find few or no issues in new decks. Re-run manually after any significant edit to a diagram.
+- **After any TikZ edit** — adding a new node, changing a bend angle, repositioning a label. Don't trust visual inspection alone; run the math.
+- **Before shipping a deck** — final pre-flight check after the deck compiles cleanly.
+- **When a diagram "looks wrong" but you can't say why** — `/tikz` will find the exact measurement causing the discomfort.
+- **On TikZ written outside of `/beautiful_deck`** — legacy diagrams, inherited decks, or hand-written TikZ. These are the cases where `/tikz` works hardest, because the upstream prevention rules (Step 4.4) were not applied. Expect more findings and more iteration.
 
-Bezier collisions:    N
-Whitespace collisions: M
-Edge clipping:        K
+## Known limitations
 
-Findings:
-  - <location>: <description>. Fix: <proposed change>.
-  - ...
-```
+- **Cannot fix autosized nodes reliably.** If a `\node` has no explicit `minimum width`/`minimum height`, its rendered dimensions depend on the text content and font — information `/tikz` can only estimate, not compute exactly. The fix is upstream: write explicit dimensions (Step 4.4, Rule 1).
+- **`scale` factor creates invisible collisions.** `scale=0.55` shrinks coordinates but not text. `/tikz` attempts to compensate, but the compensated gap calculations are less reliable than diagrams drawn at intended size. The fix is upstream: never use `scale` on complex diagrams (Step 4.4, Rule 5).
+- **Pass 6 (visual sanity check) is unreliable.** Claude cannot reliably inspect rendered PDFs at the pixel level. Passes 1–5 (measurement-based) are the real defense. Pass 6 is a belt-and-suspenders reminder, not a guarantee.
 
-Then it stops. The user reviews and edits. If they want a deeper look at one element, they invoke `/tikz` again on that scope.
+## Related skills
 
-## What this skill does NOT do
+- **`/beautiful_deck`** — invokes `/tikz` automatically as part of the visual cleanup step during end-to-end deck creation, and reads this skill's `tikz_rules.md` during Step 4.4 to prevent collisions before they are generated.
 
-- It does not iterate. One pass, one report, exit.
-- It does not re-audit the whole file after a fix. That's the quadratic blowup that killed the previous version.
-- It does not run `pdflatex` in a loop.
-- It does not eyeball multi-page PDFs.
-- It does not perform cross-slide consistency, autosized-node detection, or the four other passes the previous version did.
+## The philosophy
 
-## Typical fixes by toolchain
+The common failure mode in academic decks is not "I couldn't make this figure" — it's "the figure compiles, looks mostly right, and has one subtle overlap that distracts the audience every time they look at it." Those overlaps are invisible to LaTeX and invisible to the author because they've stared at the diagram for hours.
 
-**ggplot2 (R)**: move legend with `theme(legend.position=...)`; crowded labels with `ggrepel::geom_text_repel()`; clipping with `theme(plot.margin = margin(t,r,b,l))`.
+`/tikz` was originally written as the sole defense against these overlaps. Experience showed that a repair-only approach is insufficient — Claude reads the formulas and *simulates* having done the calculation, but doesn't always execute them rigorously. The breakthrough was recognizing that **prevention is worth ten repair passes**: writing safe TikZ from the start (explicit dimensions, coordinate maps, no `scale`) eliminates most collision classes before `/tikz` ever runs.
 
-**matplotlib (Python)**: `plt.tight_layout()` for auto-padding; save with `bbox_inches='tight'`; legend outside plot with `bbox_to_anchor`.
+The current architecture reflects this: `/beautiful_deck` Step 4.4 is the upstream defense, using the same `tikz_rules.md` reference that `/tikz` reads during repair. `/tikz` is the downstream check. Together they catch what either alone would miss. Every collision rule in `/tikz` has a formula behind it. Every formula was written down because a prior version of a Scott deck had exactly that collision, found only after the audience saw it. The skill is the accumulated scar tissue of previous deck-polishing sessions — now paired with generation rules that prevent the same scars from forming in the first place.
 
-**TikZ (LaTeX)**: declare canvas with `\useasboundingbox`; control label placement with `node[anchor=...]`; place curve labels as standalone `\node at (midpoint)` outside the arc, not as inline edge labels.
+## Full reference
+
+The canonical formula reference:
+- [`.claude/skills/tikz/tikz_rules.md`](../../.claude/skills/tikz/tikz_rules.md) — every formula, every clearance, every worked example
+- [`.claude/skills/tikz/SKILL.md`](../../.claude/skills/tikz/SKILL.md) — the operational checklist Claude follows when you invoke `/tikz`


### PR DESCRIPTION
## Summary

This PR updates the deck-generation stack around `/beautiful_deck` and `/tikz`, with `/tikz` owning the shared measurement rule book and `/beautiful_deck` using it upstream to prevent collisions before repair is needed.

## What changed

- Makes audience resolution a required first step for `/beautiful_deck`.
- Adds deck rhetoric reference files, style preferences, palettes, domain patterns, and a house-style preamble.
- Clarifies that the house-style preamble is opt-in and should not anchor original audience-specific designs.
- Strengthens title-line, microtext, image-placeholder, and Beamer layout guidance.
- Moves TikZ collision formulas into `/tikz/tikz_rules.md` as the shared rule book.
- Refactors `/tikz` into an operational checklist that reads the rule book before auditing.
- Updates public docs for the new prevention-first flow: `/beautiful_deck` Step 4.4 prevents common collisions; `/tikz` audits residual issues.

## Why

The main goal is to make generated decks more reliable before the compile/audit loop begins. In beta use, most TikZ problems were easier to prevent during generation than repair after the fact.

## Testing

- Reviewed the branch diff against the PR notes.
- Checked for stale references to the old compiledeck-owned TikZ rule book and updated the public docs accordingly.
- No automated tests were run; this is a skill/documentation protocol update.