### PR TITLE
bibcheck: split modes into sibling files and extract splitter script

### DIFF
--- a/.claude/skills/bibcheck/SKILL.md
+++ b/.claude/skills/bibcheck/SKILL.md
@@ -61,59 +61,12 @@ The timestamped folder means re-runs do not clobber prior audits.
 
 For `.tex` input, first resolve the linked `.bib` or extract `\bibitem{}` blocks into `input.bib`, then use the same run directory shape.
 
-## Step 3a: Per-citation mode
+## Step 3: Run the selected mode
 
-1. **Launch agents in waves of `--max-parallel`.** For each `entries/*.bib` file, dispatch one Agent subagent (subagent_type: general-purpose) with this brief:
+Read the mode-specific protocol file and follow it end-to-end. Only one of these fires per invocation:
 
-   ```
-   You are auditing one bibliography entry. The entry is:
-
-   <paste the .bib block>
-
-   Your job:
-   1. Identify the cited paper. Use WebSearch (and WebFetch if needed) to find it.
-   2. Locate a canonical anchor: DOI, journal landing page URL, or author working-paper URL.
-   3. Cross-check every field in the .bib block against the canonical source:
-      - title, authors, year, journal/booktitle, volume, number, pages, publisher, DOI
-   4. Specifically test for "field mixing" — e.g., the title belongs to one paper but the authors or year belong to another. This is the most common silent error in inherited .bib files.
-   5. Output JSON to <reports/<key>.json> with:
-      - status: "clean" | "corrected" | "unverifiable"
-      - one_sentence: plain-language description of the paper (one sentence)
-      - canonical_url: DOI or URL
-      - issues: list of {field, original, corrected, reason}
-      - corrected_bib: the corrected entry (or the original if status=clean)
-
-   You do NOT modify the input file. You only write the report and the corrected entry.
-   ```
-
-2. **Final reviewer pass.** When all entries are done, dispatch a single reviewer agent that:
-   - Reads every `reports/*.json`.
-   - Spot-checks any entry marked "unverifiable" (does a quick second WebSearch).
-   - Adjudicates conflicts where a corrected field looks suspicious.
-   - Writes `bibcheck_report.md` with a summary table (Clean / Corrected / Unverifiable counts) and per-entry detail.
-   - Concatenates the corrected_bib fields into `corrected.bib`.
-
-## Step 3b: Per-field mode
-
-The point of this mode is **isolation**: each specialist agent should not see what the others are concluding. We achieve that by launching each specialist as a separate `claude -p` subprocess. Each subprocess is a fresh CLI session.
-
-For each field in the list `[title, year, journal, authors, volume_issue, pages, doi]`:
-
-1. Build a prompt for the specialist that contains:
-   - The full input.bib content
-   - The field name
-   - Instructions: "For each entry in this .bib, check ONLY the {field}. Compare against the canonical paper found via WebSearch. Output JSON to stdout: a list of {key, status, original, corrected, reason}."
-
-2. Launch the specialist via Bash:
-   ```bash
-   claude --dangerously-skip-permissions -p "<the specialist prompt>" > reports/field_<field>.json 2>reports/field_<field>.log
-   ```
-
-3. Run subprocesses in parallel up to `--max-parallel`. Wait for all to complete.
-
-4. **Final reviewer pass.** A consolidator agent reads all `field_*.json`, joins by entry key, and produces:
-   - `bibcheck_report.md` — disagreements across specialists are flagged (e.g., title-specialist says X, year-specialist disagrees about which paper is being cited)
-   - `corrected.bib` — applies a field-level fix only if the relevant specialist flagged it AND the cross-field consensus supports the fix
+- **Per-citation mode** (`--by-citation`, default): see `mode_per_citation.md`. One Agent subagent per `.bib` entry; each fully audits its single entry; final reviewer consolidates.
+- **Per-field mode** (`--by-field`): see `mode_per_field.md`. One isolated `claude -p` subprocess per field; each specialist checks only its field across the whole bibliography; consolidator joins by entry key.
 
 ## Step 4: Present the result to the user
 

--- a/.claude/skills/bibcheck/SKILL.md
+++ b/.claude/skills/bibcheck/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bibcheck
 description: Many-agent bibliography audit. Verify each citation in a .bib file by spawning narrow-focus agents that confirm DOI/URL and cross-check that all fields belong to the same paper. Catches mixed-up entries (one paper's title with another's authors), wrong years, journal misattributions, and unverifiable references. Use when reviewing a manuscript's bibliography for accuracy before submission, after literature review, or when inheriting a .bib from a coauthor.
-allowed-tools: Bash(claude*), Bash(ls*), Bash(cat*), Bash(wc*), Bash(grep*), Bash(mkdir*), Bash(cp*), Read, Write, Edit, WebSearch, WebFetch, Agent
+allowed-tools: Bash(claude*), Bash(ls*), Bash(cat*), Bash(wc*), Bash(grep*), Bash(mkdir*), Bash(cp*), Bash(~/.claude/skills/bibcheck/scripts/split_bib.py:*), Read, Write, Edit, WebSearch, WebFetch, Agent
 argument-hint: '[--by-citation|--by-field] <path-to-bib-or-tex> [--max-parallel N]'
 ---
 
@@ -11,9 +11,7 @@ You are running `/bibcheck` — a verification routine that audits a bibliograph
 
 ## Why narrow agents
 
-A single agent asked to audit 80 citations in one pass tends to drift: early entries get careful treatment; later entries get pattern-matched. Splitting the work — one agent per entry, or one specialist per field across all entries — keeps each agent focused on something small and verifiable. The bottleneck shifts from agent attention to orchestration, which is what cheap parallel agents are for.
-
-See `methodology.md` for the full rationale.
+See `methodology.md` for the full gradient-decay rationale and audit standard.
 
 ## Step 0: Read your full methodology
 
@@ -42,7 +40,13 @@ Do not guess.
 
 ## Step 2: Set up the run directory
 
-Create a working folder next to the input file:
+For `.bib` input, run the splitter:
+
+```bash
+~/.claude/skills/bibcheck/scripts/split_bib.py path/to/references.bib
+```
+
+It creates:
 
 ```
 <bib_dir>/bibcheck_<timestamp>/
@@ -55,11 +59,11 @@ Create a working folder next to the input file:
 
 The timestamped folder means re-runs do not clobber prior audits.
 
+For `.tex` input, first resolve the linked `.bib` or extract `\bibitem{}` blocks into `input.bib`, then use the same run directory shape.
+
 ## Step 3a: Per-citation mode
 
-1. **Split the .bib into per-entry files.** A robust splitter: read the .bib, walk for `@type{key,` openers, balance braces to find each entry's close, write to `entries/<key>.bib`.
-
-2. **Launch agents in waves of `--max-parallel`.** For each entry, dispatch one Agent subagent (subagent_type: general-purpose) with this brief:
+1. **Launch agents in waves of `--max-parallel`.** For each `entries/*.bib` file, dispatch one Agent subagent (subagent_type: general-purpose) with this brief:
 
    ```
    You are auditing one bibliography entry. The entry is:
@@ -82,7 +86,7 @@ The timestamped folder means re-runs do not clobber prior audits.
    You do NOT modify the input file. You only write the report and the corrected entry.
    ```
 
-3. **Final reviewer pass.** When all entries are done, dispatch a single reviewer agent that:
+2. **Final reviewer pass.** When all entries are done, dispatch a single reviewer agent that:
    - Reads every `reports/*.json`.
    - Spot-checks any entry marked "unverifiable" (does a quick second WebSearch).
    - Adjudicates conflicts where a corrected field looks suspicious.

--- a/.claude/skills/bibcheck/mode_per_citation.md
+++ b/.claude/skills/bibcheck/mode_per_citation.md
@@ -1,0 +1,38 @@
+# Per-citation mode
+
+One Agent subagent per `.bib` entry. Each fully audits its single entry against canonical sources, then a final reviewer consolidates.
+
+## Step 3a.1 — Launch agents in waves of `--max-parallel`
+
+For each `entries/*.bib` file, dispatch one Agent subagent (subagent_type: general-purpose) with this brief:
+
+```
+You are auditing one bibliography entry. The entry is:
+
+<paste the .bib block>
+
+Your job:
+1. Identify the cited paper. Use WebSearch (and WebFetch if needed) to find it.
+2. Locate a canonical anchor: DOI, journal landing page URL, or author working-paper URL.
+3. Cross-check every field in the .bib block against the canonical source:
+   - title, authors, year, journal/booktitle, volume, number, pages, publisher, DOI
+4. Specifically test for "field mixing" — e.g., the title belongs to one paper but the authors or year belong to another. This is the most common silent error in inherited .bib files.
+5. Output JSON to <reports/<key>.json> with:
+   - status: "clean" | "corrected" | "unverifiable"
+   - one_sentence: plain-language description of the paper (one sentence)
+   - canonical_url: DOI or URL
+   - issues: list of {field, original, corrected, reason}
+   - corrected_bib: the corrected entry (or the original if status=clean)
+
+You do NOT modify the input file. You only write the report and the corrected entry.
+```
+
+## Step 3a.2 — Final reviewer pass
+
+When all entries are done, dispatch a single reviewer agent that:
+
+- Reads every `reports/*.json`.
+- Spot-checks any entry marked "unverifiable" (does a quick second WebSearch).
+- Adjudicates conflicts where a corrected field looks suspicious.
+- Writes `bibcheck_report.md` with a summary table (Clean / Corrected / Unverifiable counts) and per-entry detail.
+- Concatenates the corrected_bib fields into `corrected.bib`.

--- a/.claude/skills/bibcheck/mode_per_field.md
+++ b/.claude/skills/bibcheck/mode_per_field.md
@@ -1,0 +1,29 @@
+# Per-field mode
+
+One CLI subprocess per field. Each specialist reads the whole bibliography but checks only its field. The point of this mode is **isolation**: each specialist agent should not see what the others are concluding. Launching each as a separate `claude -p` subprocess gives a fresh CLI session with no shared conversation memory.
+
+See `methodology.md` for why per-field mode requires CLI isolation rather than in-conversation subagents.
+
+## Step 3b.1 — Build and launch one specialist per field
+
+For each field in the list `[title, year, journal, authors, volume_issue, pages, doi]`:
+
+1. Build a prompt for the specialist that contains:
+   - The full `input.bib` content
+   - The field name
+   - Instructions: "For each entry in this .bib, check ONLY the {field}. Compare against the canonical paper found via WebSearch. Output JSON to stdout: a list of {key, status, original, corrected, reason}."
+
+2. Launch the specialist via Bash:
+
+   ```bash
+   claude --dangerously-skip-permissions -p "<the specialist prompt>" > reports/field_<field>.json 2>reports/field_<field>.log
+   ```
+
+3. Run subprocesses in parallel up to `--max-parallel`. Wait for all to complete.
+
+## Step 3b.2 — Final reviewer pass
+
+A consolidator agent reads all `field_*.json`, joins by entry key, and produces:
+
+- `bibcheck_report.md` — disagreements across specialists are flagged (e.g., title-specialist says X, year-specialist disagrees about which paper is being cited).
+- `corrected.bib` — applies a field-level fix only if the relevant specialist flagged it AND the cross-field consensus supports the fix.

--- a/.claude/skills/bibcheck/scripts/split_bib.py
+++ b/.claude/skills/bibcheck/scripts/split_bib.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Create a bibcheck run directory and split a .bib file into per-entry files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+
+ENTRY_START = re.compile(r"@([A-Za-z]+)\s*\{\s*([^,\s]+)\s*,", re.MULTILINE)
+
+
+def find_entry_end(text: str, start: int) -> int:
+    depth = 0
+    in_quote = False
+    escaped = False
+
+    for index in range(start, len(text)):
+        char = text[index]
+
+        if escaped:
+            escaped = False
+            continue
+
+        if char == "\\":
+            escaped = True
+            continue
+
+        if char == '"':
+            in_quote = not in_quote
+            continue
+
+        if in_quote:
+            continue
+
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+
+    raise ValueError(f"Unbalanced braces starting at byte offset {start}")
+
+
+def sanitize_key(key: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", key).strip("_")
+    return safe or "entry"
+
+
+def split_entries(text: str) -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+    position = 0
+
+    while True:
+        match = ENTRY_START.search(text, position)
+        if not match:
+            break
+
+        entry_start = match.start()
+        key = match.group(2)
+        entry_end = find_entry_end(text, match.end() - 1)
+        entries.append((key, text[entry_start:entry_end].strip() + "\n"))
+        position = entry_end
+
+    return entries
+
+
+def unique_path(directory: Path, key: str) -> Path:
+    stem = sanitize_key(key)
+    path = directory / f"{stem}.bib"
+    counter = 2
+
+    while path.exists():
+        path = directory / f"{stem}_{counter}.bib"
+        counter += 1
+
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Split a .bib file into one entry per file.")
+    parser.add_argument("bib_path", type=Path, help="Input .bib file")
+    parser.add_argument("--run-dir", type=Path, default=None, help="Optional output run directory")
+    args = parser.parse_args()
+
+    bib_path = args.bib_path.expanduser().resolve()
+    if not bib_path.is_file():
+        raise SystemExit(f"Bib file not found: {bib_path}")
+
+    run_dir = args.run_dir
+    if run_dir is None:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_dir = bib_path.parent / f"bibcheck_{timestamp}"
+    else:
+        run_dir = run_dir.expanduser().resolve()
+
+    entries_dir = run_dir / "entries"
+    reports_dir = run_dir / "reports"
+    entries_dir.mkdir(parents=True, exist_ok=False)
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    input_copy = run_dir / "input.bib"
+    shutil.copy2(bib_path, input_copy)
+
+    text = bib_path.read_text(encoding="utf-8")
+    entries = split_entries(text)
+    if not entries:
+        raise SystemExit(f"No BibTeX entries found in: {bib_path}")
+
+    for key, entry_text in entries:
+        unique_path(entries_dir, key).write_text(entry_text, encoding="utf-8")
+
+    print(f"Run directory: {run_dir}")
+    print(f"Input copy: {input_copy}")
+    print(f"Entries: {len(entries)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two small follow-up changes to `/bibcheck`. (1) Splits the two operating modes (per-citation, per-field) into sibling files so SKILL.md only carries shared context. (2) Extracts the inline `.bib` splitter into a standalone script under `scripts/split_bib.py`.

Both changes are intended to reduce per-invocation token cost without altering audit behavior.

## What changed

- New `mode_per_citation.md`: holds the Step 3a prompt template + consolidator pass for the default `--by-citation` mode.
- New `mode_per_field.md`: holds the Step 3b prompt template + consolidator pass for `--by-field`.
- `SKILL.md` shrinks from 144 → 97 lines, pointing into whichever mode file is selected. Since only one mode fires per invocation, the unused mode no longer occupies the loaded context.
- New `scripts/split_bib.py`: the previously inline `.bib` splitting logic, extracted to a reusable script. SKILL.md now invokes it via `~/.claude/skills/bibcheck/scripts/split_bib.py` and references it in `allowed-tools`.

## Why

- **Mode split**: only one mode runs per invocation. Carrying the other mode's prompt template in SKILL.md is dead weight on every call.
- **Script extraction**: keeps the deterministic `.bib`-chunking logic out of the LLM context entirely and makes it independently testable / re-runnable.

## Testing

- Verified `mode_per_citation.md` and `mode_per_field.md` carry the exact prompt templates and consolidator instructions that previously lived in SKILL.md.
- Confirmed `SKILL.md` references the new sibling files and the extracted script path.
- Ran `split_bib.py` against a sample `.bib` to confirm chunking output matches the prior inline behavior.
- No behavior change in audit output expected — this is a context/file-layout refactor only.